### PR TITLE
Filter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ck3-tiger <i>path/to/your/</i>descriptor.mod ><i>filename</i>
 ## How to configure
 You can place a file `ck3-tiger.conf` in your mod directory. You can use it to select which languages to check localizations for, and to suppress messages about things you don't want to fix.
 
-There is a sample `ck3-tiger.conf` file in the release, with an explanation of what goes in it.
+There is a sample [`ck3-tiger.conf`](ck3-tiger.conf) file in the release, with an explanation of what goes in it. There is also a [guide](filter.md).
 
 ## How to build
 You can unpack the archive from the "Release" page on GitHub and use it that way.

--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -13,21 +13,33 @@ languages = {
 	# If you don't specify anything in languages, the validator will check all languages.
 }
 
-# There can be multiple ignore sections.
-ignore = {
-	# This will ignore the specified warnings.
+# Allows configuring what reports are printed by CK3-Tiger.
+filter = {
 
-	# Each key entry specifies a key to ignore.
-	# The key names are in the output, in parentheses after ERROR or WARNING.
-	# If there are no keys, all errors in the specified files will be ignored.
-	key = brace-placement
+    # Whether to report about problems in vanilla game files.
+    # Setting this to 'yes' results in a LOT of spam.
+    # Optional boolean value, defaults to no.
+    show_vanilla = no
 
-	# Each file entry specifies a file in which to ignore the specified key or keys.
-	# If there are no file entries, the keys are ignored in all files.
-	file = events/POD_initialization/POD_maintenance_events.txt
+    # Whether to report about problems in mods loaded via the load_mod sections.
+    # Optional boolean value, defaults to no.
+    show_loaded_mods = no
 
-	# The file entry can be a whole folder if you like.
-	file = history/characters
+    # Contains rules for reports, using trigger syntax.
+    # Only reports matching the trigger will be printed.
+    # The root trigger is an AND block, just like any other trigger.
+    trigger = {
+        # For more information, there is a guide at: ck3-tiger/filter.md
+
+        # In short, valid trigger keys are:
+        # - always = yes/no
+        # - NOT, AND, OR, NAND, NOR
+        # - severity
+        # - confidence
+        # - key
+        # - file
+    }
+
 }
 
 # Use a load_mod section to tell ck3-tiger to load another mod before this one.
@@ -66,24 +78,24 @@ output_style = {
     enable = yes
 
     # Optional block to set the error color.
-    error = {
-        # Default is red. Supported values are Black, Red, Green, Yellow, Blue, Purple, Cyan, White.
-        color = "red"
-    }
+#    error = {
+#        # Default is red. Supported values are Black, Red, Green, Yellow, Blue, Purple, Cyan, White.
+#        color = "red"
+#    }
     # Optional block to set the warning color.
-    warning = {
-        # Default is yellow. Supported values are Black, Red, Green, Yellow, Blue, Purple, Cyan, White.
-        color = "yellow"
-    }
+#    warning = {
+#        # Default is yellow. Supported values are Black, Red, Green, Yellow, Blue, Purple, Cyan, White.
+#        color = "yellow"
+#    }
     # Optional block to set the info color.
-    info = {
-        # Default is green. Supported values are Black, Red, Green, Yellow, Blue, Purple, Cyan, White.
-        color = "green"
-    }
+#    info = {
+#        # Default is green. Supported values are Black, Red, Green, Yellow, Blue, Purple, Cyan, White.
+#        color = "green"
+#    }
     # Optional block to set the advice color.
-    untidy = {
-        # Default is blue. Supported values are Black, Red, Green, Yellow, Blue, Purple, Cyan, White.
-        color = "cyan"
-    }
+#    untidy = {
+#        # Default is cyan. Supported values are Black, Red, Green, Yellow, Blue, Purple, Cyan, White.
+#        color = "cyan"
+#    }
 
 }

--- a/ck3-tiger/src/main.rs
+++ b/ck3-tiger/src/main.rs
@@ -7,11 +7,10 @@ use home::home_dir;
 
 use tiger_lib::everything::Everything;
 use tiger_lib::modfile::ModFile;
+use tiger_lib::report::set_vanilla_dir;
 use tiger_lib::report::{
-    disable_ansi_colors, set_mod_root,
-    set_show_loaded_mods, set_show_vanilla
+    disable_ansi_colors, set_mod_root, set_show_loaded_mods, set_show_vanilla,
 };
-use tiger_lib::report::{set_vanilla_dir};
 #[cfg(windows)]
 use winreg::enums::HKEY_LOCAL_MACHINE;
 #[cfg(windows)]

--- a/filter.md
+++ b/filter.md
@@ -1,0 +1,223 @@
+# Filtering the output
+
+Tiger generates a lot of reports. This guide explains how to use filters to control what reports are printed.
+
+In the `ck3-tiger.conf` file, add a `filter` block. Inside the `filter`, add a `trigger` block.
+
+```
+# You can have at most 1 filter block.
+filter = {
+    # Whether to report about problems in vanilla game files.
+    # Setting this to 'yes' results in a LOT of spam.
+    # Optional boolean value, defaults to no.
+    show_vanilla = no
+
+    # Whether to report about problems in mods loaded via the load_mod sections.
+    # Optional boolean value, defaults to no.
+    show_loaded_mods = no
+    
+    # You can have at most 1 trigger block. It is an implicit AND trigger, just like in paradox script.
+    trigger = {
+        # Read on to see what triggers can be used here.
+    }
+}
+```
+
+## Triggers
+
+This is the list of valid triggers that can be used in the `trigger` block.
+
+### always
+
+- `always = yes` matches all reports
+- `always = no` matches no reports
+
+### Logic gates
+
+You can use any of the following logic gates.
+
+- `NOT = { <trigger> }`
+    - True if the trigger is false.
+- `AND = { <trigger> <trigger> ... }`
+    - True if all triggers are true.
+    - An empty `AND` block is the same as `always = yes`.
+- `OR = { <trigger> <trigger> ... }`
+    - True if at least one trigger is true.
+    - An empty `OR` block is the same as `always = no`.
+- `NAND = { <trigger> <trigger> ... }`
+    - True unless all triggers are true.
+    - This is the same as writing `NOT = { AND = { } }`
+- `NOR = { <trigger> <trigger> ... }`
+    - True if all triggers are false.
+    - This is the same as writing `NOT = { OR = { } }`
+
+### Severity
+
+Severity is a measure of the seriousness of the problem. For example; using the wrong level of indentation is an
+extremely minor problem that wouldn't impact the functionality of the mod at all. It is a low severity.
+Conversely, a problem that causes the game to crash on start-up is of the highest severity.
+
+These are the severity levels:
+
+- `Tips` These are things that aren't necessarily wrong, but there may be a better, more idiomatic way to do it. This
+  may also include performance issues.
+- `Untidy` This code smells. The player is unlikely to be impacted directly, but developers working on this codebase
+  will likely experience maintenance headaches.
+- `Warning` This will result in glitches that will noticeably impact the player's gaming experience. Missing
+  translations are an example.
+- `Error` This code probably doesn't work as intended. The player may experience bugs.
+- `Fatal` This is likely to cause crashes.
+
+You can add the severity trigger like so:
+
+- `severity = Tips` (Only match tips.)
+- `severity >= Warning` (Match Warnings or higher.)
+- `severity < Error` (Match anything below Error.)
+
+### Confidence
+
+Describes how confident Tiger is that a problem is real and not a false positive. If you are spammed with many false
+positives, you may try raising the required confidence level.
+
+These are the current confidence levels. They are subject to change.
+
+- `Weak` Tiger is not very confident about this report, it's quite likely to be a false positive.
+- `Reasonable` The default level.
+- `Strong` Tiger is very confident that this is a real problem.
+
+You can add the confidence trigger like so:
+
+- `confidence = Weak` (Only match weak.)
+- `confidence >= Reasonable` (Match Reasonable or higher.)
+- `confidence < Strong` (Match anything below Strong.)
+
+### Key
+
+Every report has a `key`, it describes the type of problem that is being reported about. You can find the key in
+parentheses on the first line of the report. For example, in the report below, the key is `missing-localization`:
+
+```
+Error(missing-localization): missing english localization key Badlay
+   --> [CK3] history/characters/afar.txt
+267 |  name = "Badlay"
+    |         ^ 
+```
+
+You can add a key trigger like so:
+
+- `key = missing-localization` This will match reports with the `missing-localization` key.
+
+### File
+
+You can target files and folders. Reports that mention the file will be matched by this trigger.
+
+Example:
+
+- `file = common/` This matches any report that mentions a file inside the `common/` directory.
+- `file = history/characters/afar.txt` This matches any report that mentions that specific file.
+
+# Migrating from `ignore` to `filter`
+
+Filtering was previously done through `ignore` blocks.
+
+Suppose this is our old setup:
+
+```
+ignore = {
+    key = duplicate-field
+}
+ignore = {
+    file = events/travel_events/travel_events.txt
+}
+ignore = {
+    key = duplicate-item
+    file = common/decisions/80_major_decisions.txt
+    file = common/script_values/00_basic_values.txt
+    file = common/defines/00_defines.txt
+}
+```
+
+We can replicate this like so:
+
+```
+trigger = {
+    NOR = {
+        key = duplicate-field
+        file = events/travel_events/travel_events.txt
+    }
+    NAND = {
+        key = duplicate-item
+        OR = {
+            file = common/decisions/80_major_decisions.txt
+            file = common/script_values/00_basic_values.txt
+            file = common/defines/00_defines.txt
+        }
+    }
+}
+```
+
+# Examples
+
+## Filter by severity
+
+```
+trigger = {
+    # Only print Warnings or above:
+    severity >= Warning
+    # Don't print reports that are likely false positives:
+    confidence > Weak
+}
+```
+
+## Whitelist the folder you're working on
+
+```
+trigger = {
+    # Only reports about files inside this folder will be printed.
+    file = common/traits/
+}
+```
+
+## Ignore a certain key
+
+```
+trigger = {
+    # I don't care about localization (yet), I'll add the translations later!!!
+    NOT = { key = missing-localization }
+}
+```
+
+## All of the above
+
+A more realistic case. You're working on implementing custom traits, and want to see warnings and errors specific to
+traits. You're planning on adding translations later, so you temporarily blacklisted that particular key.
+
+```
+trigger = {
+    # Only print warnings and errors:
+    severity >= Warning
+    # Don't print reports that are likely false positives:
+    confidence >= Reasonable
+    # Only reports about files inside this folder will be printed.
+    file = common/traits/
+    # I don't care about localization (yet), I'll add the translations later!!!
+    NOT = { key = missing-localization }
+}
+```
+
+## Custom severity level for spammy file
+
+```
+trigger = {
+    
+    # For most files, print warnings and errors:
+    severity >= Warnings
+    
+    # For this very spammy file, only print errors:
+    NAND = {
+        severity < Error
+        file = a/very/spammy/file.txt
+    }
+
+}
+```

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,3 +1,4 @@
+use crate::block::Eq::{Double, Question, Single};
 use std::borrow::Cow;
 use std::fmt::{Display, Error, Formatter};
 use std::rc::Rc;
@@ -316,7 +317,7 @@ impl Block {
         let mut vec = Vec::new();
         for (k, cmp, v) in &self.v {
             if let Some(key) = k {
-                if matches!(cmp, Comparator::Eq) {
+                if matches!(cmp, Comparator::Equals(Single)) {
                     match v {
                         BV::Value(t) => vec.push((key, t)),
                         BV::Block(_) => (),
@@ -554,15 +555,10 @@ impl Block {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Comparator {
     /// TODO: Can perhaps be replaced by wrapping the operator in an option.
+    /// Deprecated.
     None,
-    /// The = operator. Can be used as assignment, or to open a scope.
-    /// TODO: Can perhaps be merged with the other one.
-    ///       If preserving knowledge of notation used is important, maybe we could do: Equals(u8) or something?
-    Eq,
-    /// The ?= operator Can be used to open a scope on the condition that it exists.
-    ConditionalEquals,
-    /// ==
-    Equals,
+    /// =, ?=, ==,
+    Equals(Eq),
     /// !=
     NotEquals,
     /// <
@@ -575,14 +571,27 @@ pub enum Comparator {
     AtLeast,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Eq {
+    /// Notation: =
+    /// Valid as an equality comparison operator, assignment operator and scope opener.
+    Single,
+    /// Notation: ==
+    /// Only valid as an equality comparison operator.
+    Double,
+    /// Notation: ?=
+    /// Valid as a conditional equality comparison operator and condition scope opener.
+    Question,
+}
+
 impl Comparator {
     pub fn from_str(s: &str) -> Option<Self> {
         if s == "=" {
-            Some(Comparator::Eq)
-        } else if s == "?=" {
-            Some(Comparator::ConditionalEquals)
+            Some(Comparator::Equals(Single))
         } else if s == "==" {
-            Some(Comparator::Equals)
+            Some(Comparator::Equals(Double))
+        } else if s == "?=" {
+            Some(Comparator::Equals(Question))
         } else if s == "<" {
             Some(Comparator::LessThan)
         } else if s == ">" {
@@ -600,41 +609,14 @@ impl Comparator {
     pub fn from_token(token: &Token) -> Option<Self> {
         Self::from_str(token.as_str())
     }
-
-    /// Returns true if the operator is a comparison operator, or if it's an `=` operator,
-    /// which serves as an alias for the equality comparator.
-    pub fn is_comparator(self) -> bool {
-        matches!(
-            self,
-            Comparator::Eq
-                | Comparator::Equals
-                | Comparator::NotEquals
-                | Comparator::AtLeast
-                | Comparator::AtMost
-                | Comparator::GreaterThan
-                | Comparator::LessThan
-        )
-    }
-    /// Substitutes `==` for `=`.
-    /// This is to allow `=` to be used as an alias for equality,
-    /// even though that's technically incorrect.
-    pub fn to_comparator(self) -> Self {
-        if self == Self::Eq {
-            Self::Equals
-        } else if self.is_comparator() {
-            self
-        } else {
-            panic!("Cannot convert {self} to comparator operator. Check is_comparator() first.");
-        }
-    }
 }
 
 impl Display for Comparator {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match *self {
-            Comparator::Eq => write!(f, "="),
-            Comparator::Equals => write!(f, "=="),
-            Comparator::ConditionalEquals => write!(f, "?="),
+            Comparator::Equals(Single) => write!(f, "="),
+            Comparator::Equals(Double) => write!(f, "=="),
+            Comparator::Equals(Question) => write!(f, "?="),
             Comparator::LessThan => write!(f, "<"),
             Comparator::GreaterThan => write!(f, ">"),
             Comparator::AtMost => write!(f, "<="),
@@ -657,7 +639,7 @@ impl<'a> Iterator for IterAssignments<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         for (k, cmp, bv) in self.iter.by_ref() {
             if let Some(key) = k {
-                if !matches!(cmp, Comparator::Eq) {
+                if !matches!(cmp, Comparator::Equals(Single)) {
                     if self.warn {
                         let msg = format!("expected `{key} =`, found `{cmp}`");
                         error(key, ErrorKey::Validation, &msg);
@@ -793,7 +775,7 @@ impl<'a> Iterator for IterBlockValueDefinitions<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         for (k, cmp, bv) in self.iter.by_ref() {
             if let Some(key) = k {
-                if !matches!(cmp, Comparator::Eq) {
+                if !matches!(cmp, Comparator::Equals(Single)) {
                     if self.warn {
                         error(
                             key,

--- a/src/block/validator.rs
+++ b/src/block/validator.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
-use crate::block::{Block, Comparator, Date, Token, BV};
+use crate::block::{Block, Date, Comparator, Token, BV};
 use crate::context::ScopeContext;
 use crate::everything::Everything;
 use crate::helpers::dup_assign_error;
@@ -1162,7 +1162,7 @@ impl<'a> Validator<'a> {
     fn expect_eq_qeq(&self, key: &Token, cmp: Comparator) {
         #[allow(clippy::collapsible_else_if)]
         if self.allow_qeq {
-            if !matches!(cmp, Comparator::Eq | Comparator::QEq) {
+            if !matches!(cmp, Comparator::Eq | Comparator::ConditionalEquals) {
                 let msg = format!("expected `{key} =` or `?=`, found `{cmp}`");
                 error(key, ErrorKey::Validation, &msg);
             }

--- a/src/block/validator.rs
+++ b/src/block/validator.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
-use crate::block::{Block, Date, Comparator, Token, BV};
+use crate::block::{Block, Comparator, Date, Eq::*, Token, BV};
 use crate::context::ScopeContext;
 use crate::everything::Everything;
 use crate::helpers::dup_assign_error;
@@ -1162,12 +1162,12 @@ impl<'a> Validator<'a> {
     fn expect_eq_qeq(&self, key: &Token, cmp: Comparator) {
         #[allow(clippy::collapsible_else_if)]
         if self.allow_qeq {
-            if !matches!(cmp, Comparator::Eq | Comparator::ConditionalEquals) {
+            if !matches!(cmp, Comparator::Equals(Single | Question)) {
                 let msg = format!("expected `{key} =` or `?=`, found `{cmp}`");
                 error(key, ErrorKey::Validation, &msg);
             }
         } else {
-            if !matches!(cmp, Comparator::Eq) {
+            if !matches!(cmp, Comparator::Equals(Single)) {
                 let msg = format!("expected `{key} =`, found `{cmp}`");
                 error(key, ErrorKey::Validation, &msg);
             }

--- a/src/data/localization.rs
+++ b/src/data/localization.rs
@@ -14,7 +14,7 @@ use crate::item::Item;
 use crate::parse::localization::{parse_loca, ValueParser};
 use crate::report::{
     advice_info, error, error_info, warn, warn2, warn_abbreviated, warn_header, warn_info,
-    will_log, ErrorKey,
+    will_maybe_log, ErrorKey,
 };
 use crate::token::Token;
 
@@ -366,7 +366,7 @@ impl Localization {
                 vec.sort_unstable_by_key(|entry| &entry.key.loc);
                 let mut printed_header = false;
                 for entry in vec {
-                    if !printed_header && will_log(&entry.key, ErrorKey::UnusedLocalization) {
+                    if !printed_header && will_maybe_log(&entry.key, ErrorKey::UnusedLocalization) {
                         warn_header(
                             ErrorKey::UnusedLocalization,
                             &format!("Unused localization - {lang}:\n"),

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -335,7 +335,7 @@ pub fn validate_effect<'a>(
 
         // Check if it's a target = { target_scope } block.
         sc.open_builder();
-        if validate_scope_chain(key, data, sc, matches!(cmp, Comparator::QEq)) {
+        if validate_scope_chain(key, data, sc, matches!(cmp, Comparator::ConditionalEquals)) {
             sc.finalize_builder();
             if key.starts_with("flag:") {
                 let msg = "as of 1.9, flag literals can not be used on the left-hand side";

--- a/src/effect.rs
+++ b/src/effect.rs
@@ -1,5 +1,5 @@
 use crate::block::validator::Validator;
-use crate::block::{Block, Comparator, BV};
+use crate::block::{Block, Comparator, Eq::*, BV};
 use crate::context::ScopeContext;
 use crate::data::effect_localization::EffectLocalization;
 use crate::desc::validate_desc;
@@ -335,7 +335,7 @@ pub fn validate_effect<'a>(
 
         // Check if it's a target = { target_scope } block.
         sc.open_builder();
-        if validate_scope_chain(key, data, sc, matches!(cmp, Comparator::ConditionalEquals)) {
+        if validate_scope_chain(key, data, sc, matches!(cmp, Comparator::Equals(Question))) {
             sc.finalize_builder();
             if key.starts_with("flag:") {
                 let msg = "as of 1.9, flag literals can not be used on the left-hand side";

--- a/src/effect_validation.rs
+++ b/src/effect_validation.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use crate::block::validator::Validator;
+use crate::block::Eq::Single;
 use crate::block::{Block, Comparator, BV};
 use crate::context::ScopeContext;
 use crate::desc::validate_desc;
@@ -805,7 +806,7 @@ pub fn validate_effect_block(
                         let synthetic_bv = BV::Value(key.clone());
                         validate_trigger_key_bv(
                             &target,
-                            Comparator::Eq,
+                            Comparator::Equals(Single),
                             &synthetic_bv,
                             data,
                             sc,

--- a/src/fileset.rs
+++ b/src/fileset.rs
@@ -14,7 +14,7 @@ use crate::everything::Everything;
 use crate::everything::FilesError;
 use crate::modfile::ModFile;
 use crate::report::{
-    add_loaded_mod_root, error, warn_abbreviated, warn_header, will_log, ErrorKey,
+    add_loaded_mod_root, error, warn_abbreviated, warn_header, will_maybe_log, ErrorKey,
 };
 use crate::token::{Loc, Token};
 
@@ -458,7 +458,7 @@ impl Fileset {
         }
         let mut printed_header = false;
         for entry in vec {
-            if !printed_header && will_log(entry, ErrorKey::UnusedFile) {
+            if !printed_header && will_maybe_log(entry, ErrorKey::UnusedFile) {
                 warn_header(ErrorKey::UnusedFile, "Unused DDS files:\n");
                 printed_header = true;
             }

--- a/src/parse/pdxfile.rs
+++ b/src/parse/pdxfile.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use fnv::FnvHashMap;
 
+use crate::block::Eq::Single;
 use crate::block::{Block, Comparator, BV};
 use crate::fileset::{FileEntry, FileKind};
 use crate::report::{error, warn, warn_info, ErrorKey};
@@ -324,7 +325,7 @@ impl Parser {
         let cmp = Comparator::from_token(&token).unwrap_or_else(|| {
             let msg = format!("Unrecognized comparator '{token}'");
             error(&token, ErrorKey::ParseError, &msg);
-            Comparator::Eq
+            Comparator::Equals(Single)
         });
 
         if self.current.key.is_none() {

--- a/src/report/errors.rs
+++ b/src/report/errors.rs
@@ -9,9 +9,10 @@ use fnv::{FnvHashMap, FnvHashSet};
 use crate::fileset::FileKind;
 use crate::report::error_loc::ErrorLoc;
 use crate::report::filter::ReportFilter;
+use crate::report::report_struct::LogLevel;
 use crate::report::writer::log_report;
 use crate::report::{
-    Confidence, ErrorKey, FilterRule, LogLevel, LogReport, OutputStyle, PointedMessage, Severity,
+    Confidence, ErrorKey, FilterRule, LogReport, OutputStyle, PointedMessage, Severity,
 };
 use crate::token::Loc;
 

--- a/src/report/filter.rs
+++ b/src/report/filter.rs
@@ -93,23 +93,23 @@ impl FilterRule {
             FilterRule::Conjunction(children) => children.iter().all(|child| child.apply(report)),
             FilterRule::Disjunction(children) => children.iter().any(|child| child.apply(report)),
             FilterRule::Negation(child) => !child.apply(report),
-            FilterRule::Severity(operator, level) => match operator {
-                Comparator::Equals => report.lvl.severity == *level,
+            FilterRule::Severity(comparator, level) => match comparator {
+                Comparator::Equals(_) => report.lvl.severity == *level,
                 Comparator::NotEquals => report.lvl.severity != *level,
                 Comparator::GreaterThan => report.lvl.severity > *level,
                 Comparator::AtLeast => report.lvl.severity >= *level,
                 Comparator::LessThan => report.lvl.severity < *level,
                 Comparator::AtMost => report.lvl.severity <= *level,
-                _ => panic!("Encountered unexpected operator: {operator}"),
+                Comparator::None => panic!("Encountered unexpected operator: {comparator}"),
             },
-            FilterRule::Confidence(operator, level) => match operator {
-                Comparator::Equals => report.lvl.confidence == *level,
+            FilterRule::Confidence(comparator, level) => match comparator {
+                Comparator::Equals(_) => report.lvl.confidence == *level,
                 Comparator::NotEquals => report.lvl.confidence != *level,
                 Comparator::GreaterThan => report.lvl.confidence > *level,
                 Comparator::AtLeast => report.lvl.confidence >= *level,
                 Comparator::LessThan => report.lvl.confidence < *level,
                 Comparator::AtMost => report.lvl.confidence <= *level,
-                _ => panic!("Encountered unexpected operator: {operator}"),
+                Comparator::None => panic!("Encountered unexpected operator: {comparator}"),
             },
             FilterRule::Key(key) => report.key == *key,
             FilterRule::File(path) => report

--- a/src/report/filter.rs
+++ b/src/report/filter.rs
@@ -1,0 +1,121 @@
+use std::path::PathBuf;
+
+use crate::block::Comparator;
+
+use crate::fileset::FileKind;
+use crate::report::{Confidence, ErrorKey, LogLevel, LogReport, Severity};
+use crate::token::Loc;
+
+/// Determines whether a given Report should be printed.
+/// If a report is matched by both the blacklist and the whitelist, it will not be printed.
+#[derive(Default, Debug)]
+pub struct ReportFilter {
+    /// Whether to log errors in vanilla CK3 files
+    pub show_vanilla: bool,
+    /// Whether to log errors in other loaded mods
+    pub show_loaded_mods: bool,
+    /// A complex trigger that evaluates a report to assess whether it should be printed.
+    pub predicate: FilterRule,
+}
+
+impl ReportFilter {
+    /// Returns true iff the report should be printed.
+    /// A print will be rejected if the report matches at least one of the following conditions:
+    /// - Its Severity or Confidence level is too low.
+    /// - It's from vanilla or a loaded mod and the program is configured to ignore those locations.
+    /// - The filter has a whitelist, and the report doesn't match it.
+    /// - The filter has a blacklist, and the report does match it.
+    pub fn should_print_report(&self, report: &LogReport) -> bool {
+        if report.key == ErrorKey::Config {
+            // Any errors concerning the Config should be easy to fix and will fundamentally
+            // undermine the operation of the application. They must always be printed.
+            return true;
+        }
+        // If every single Loc in the chain is out of scope, the report is out of scope.
+        let out_of_scope = report.pointers.iter().map(|p| &p.location).all(|loc| {
+            (loc.kind <= FileKind::Vanilla && !self.show_vanilla)
+                || (matches!(loc.kind, FileKind::LoadedMod(_)) && !self.show_loaded_mods)
+        });
+        if out_of_scope {
+            return false;
+        }
+        self.predicate.apply(report)
+    }
+    /// TODO: Check the filter rules to be more sure.
+    pub fn should_maybe_print(&self, _lvl: LogLevel, key: ErrorKey, location: &Loc) -> bool {
+        if key == ErrorKey::Config {
+            // Any errors concerning the Config should be easy to fix and will fundamentally
+            // undermine the operation of the application. They must always be printed.
+            return true;
+        }
+        if (location.kind <= FileKind::Vanilla && !self.show_vanilla)
+            || (matches!(location.kind, FileKind::LoadedMod(_)) && !self.show_loaded_mods)
+        {
+            return false;
+        }
+        true
+    }
+}
+
+#[derive(Default, Debug)]
+pub enum FilterRule {
+    /// Always true.
+    #[default]
+    Tautology,
+    /// Always false.
+    Contradiction,
+    /// Configured by the AND-key. The top-level rule is always a conjunction.
+    /// Reports must match all enclosed rules to match the conjunction.
+    Conjunction(Vec<FilterRule>),
+    /// Configured by the OR-key.
+    /// Reports must match at least one of the enclosed rules to match the disjunction.
+    Disjunction(Vec<FilterRule>),
+    /// Configured by the NOT-key.
+    /// Reports must not match the enclosed rule to match the negation.
+    Negation(Box<FilterRule>),
+    /// Reports must be within the given Severity range to match the rule.
+    /// The condition is built as such: `report.lvl.severity OPERATOR SEVERITY`
+    Severity(Comparator, Severity),
+    /// Reports must be within the given Confidence range to match the rule.
+    /// The condition is built as such: `report.lvl.confidence OPERATOR CONFIDENCE`
+    Confidence(Comparator, Confidence),
+    /// The report's `ErrorKey` must be the listed key for the report to match the rule.
+    Key(ErrorKey),
+    /// The report's pointers must contain the given file for the report to match the rule.
+    File(PathBuf),
+}
+
+impl FilterRule {
+    fn apply(&self, report: &LogReport) -> bool {
+        match self {
+            FilterRule::Tautology => true,
+            FilterRule::Contradiction => false,
+            FilterRule::Conjunction(children) => children.iter().all(|child| child.apply(report)),
+            FilterRule::Disjunction(children) => children.iter().any(|child| child.apply(report)),
+            FilterRule::Negation(child) => !child.apply(report),
+            FilterRule::Severity(operator, level) => match operator {
+                Comparator::Equals => report.lvl.severity == *level,
+                Comparator::NotEquals => report.lvl.severity != *level,
+                Comparator::GreaterThan => report.lvl.severity > *level,
+                Comparator::AtLeast => report.lvl.severity >= *level,
+                Comparator::LessThan => report.lvl.severity < *level,
+                Comparator::AtMost => report.lvl.severity <= *level,
+                _ => panic!("Encountered unexpected operator: {operator}"),
+            },
+            FilterRule::Confidence(operator, level) => match operator {
+                Comparator::Equals => report.lvl.confidence == *level,
+                Comparator::NotEquals => report.lvl.confidence != *level,
+                Comparator::GreaterThan => report.lvl.confidence > *level,
+                Comparator::AtLeast => report.lvl.confidence >= *level,
+                Comparator::LessThan => report.lvl.confidence < *level,
+                Comparator::AtMost => report.lvl.confidence <= *level,
+                _ => panic!("Encountered unexpected operator: {operator}"),
+            },
+            FilterRule::Key(key) => report.key == *key,
+            FilterRule::File(path) => report
+                .pointers
+                .iter()
+                .any(|pointer| pointer.location.pathname.starts_with(path)),
+        }
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,11 +1,13 @@
 pub use error_key::ErrorKey;
 pub use error_loc::ErrorLoc;
 pub use errors::*;
+pub use filter::FilterRule;
 pub use output_style::OutputStyle;
 pub use report_struct::{Confidence, LogLevel, LogReport, PointedMessage, Severity};
 mod error_key;
 mod error_loc;
 mod errors;
+mod filter;
 mod output_style;
 mod report_struct;
 mod writer;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -4,6 +4,7 @@ pub use errors::*;
 pub use filter::FilterRule;
 pub use output_style::OutputStyle;
 pub use report_struct::{Confidence, LogLevel, LogReport, PointedMessage, Severity};
+
 mod error_key;
 mod error_loc;
 mod errors;

--- a/src/report/output_style.rs
+++ b/src/report/output_style.rs
@@ -58,10 +58,10 @@ impl Default for OutputStyle {
         map.insert(Styled::Tag(Severity::Error, false), Red.bold());
         map.insert(Styled::Tag(Severity::Warning, true), Yellow.bold());
         map.insert(Styled::Tag(Severity::Warning, false), Yellow.normal());
-        map.insert(Styled::Tag(Severity::Info, true), Green.bold());
-        map.insert(Styled::Tag(Severity::Info, false), Green.normal());
         map.insert(Styled::Tag(Severity::Untidy, true), Cyan.bold());
         map.insert(Styled::Tag(Severity::Untidy, false), Cyan.normal());
+        map.insert(Styled::Tag(Severity::Tips, true), Green.bold());
+        map.insert(Styled::Tag(Severity::Tips, false), Green.normal());
 
         OutputStyle { map }
     }

--- a/src/report/report_struct.rs
+++ b/src/report/report_struct.rs
@@ -1,7 +1,8 @@
-use crate::report::ErrorKey;
-use crate::token::Loc;
 use strum_macros::EnumString;
 use strum_macros::{Display, EnumIter};
+
+use crate::report::ErrorKey;
+use crate::token::Loc;
 
 /// Describes a report about a potentially problematic situation that can be logged.
 #[derive(Debug)]
@@ -67,7 +68,7 @@ impl LogLevel {
     /// The lowest possible log level. If used as a filter, this will match everything.
     pub fn min() -> Self {
         LogLevel {
-            severity: Severity::Untidy,
+            severity: Severity::Tips,
             confidence: Confidence::Weak,
         }
     }
@@ -75,27 +76,39 @@ impl LogLevel {
 
 /// Determines the output colour.
 /// User can also filter by minimum severity level: e.g. don't show me Info-level messages.
+///
+/// The order of these enum values determines the level of severity they denote.
+/// Do not change the order unless you mean to change the logic of the program!
 #[derive(
     Default, Debug, Display, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, EnumString, EnumIter,
 )]
 pub enum Severity {
-    /// This problem likely will not affect the end-user, but is just sloppy code.
-    /// It constitutes technical debt that will increase maintenance costs.
+    /// These are things that aren't necessarily wrong, but there may be a better, more
+    /// idiomatic way to do it. This may also include performance issues.
+    Tips,
+    /// This code smells.
+    /// The player is unlikely to be impacted directly, but developers working on this codebase
+    /// will likely experience maintenance headaches.
     Untidy,
-    /// The problem may lead to minor glitches, but won't seriously affect gameplay.
-    Info,
-    /// The problem may lead to features not working, unexpected behaviour and other
-    /// bugs that will noticeably impact the end-user's experience playing the game.
+    /// This will result in glitches that will noticeably impact the player's gaming experience.
+    /// Missing translations are an example.
     #[default]
     Warning,
-    /// The problem can potentially cause crashes.
+    /// This code probably doesn't work as intended. The player may experience bugs.
     Error,
+    /// This is likely to cause crashes.
+    Fatal,
 }
 
 /// Mostly invisible in the output.
 /// User can filter by minimum confidence level.
 /// This would be a dial for how many false positives they're willing to put up with.
-#[derive(Default, Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, EnumString)]
+///
+/// The order of these enum values determines the level of confidence they denote.
+/// Do not change the order unless you mean to change the logic of the program!
+#[derive(
+    Default, Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, EnumString, EnumIter,
+)]
 pub enum Confidence {
     /// Quite likely to be a false positive.
     Weak,

--- a/src/report/writer.rs
+++ b/src/report/writer.rs
@@ -96,7 +96,7 @@ fn log_line_title(errors: &Errors, report: &LogReport) {
         errors
             .styles
             .style(&Styled::ErrorMessage)
-            .paint(format!("{}", report.msg)),
+            .paint(report.msg.to_string()),
     ];
     println!("{}", ANSIStrings(line));
 }
@@ -113,7 +113,7 @@ fn log_line_info(errors: &Errors, indentation: usize, info: &str) {
         errors.styles.style(&Styled::Default).paint(" "),
         errors.styles.style(&Styled::InfoTag).paint("Info:"),
         errors.styles.style(&Styled::Default).paint(" "),
-        errors.styles.style(&Styled::Info).paint(format!("{info}")),
+        errors.styles.style(&Styled::Info).paint(info.to_string()),
     ];
     println!("{}", ANSIStrings(line_info));
 }
@@ -154,7 +154,7 @@ fn log_line_from_source(errors: &Errors, pointer: &PointedMessage, indentation: 
         errors
             .styles
             .style(&Styled::SourceText)
-            .paint(format!("{line}")),
+            .paint(line.to_string()),
     ];
     println!("{}", ANSIStrings(line_from_source));
 }
@@ -189,7 +189,7 @@ fn log_line_carets(
         errors
             .styles
             .style(&Styled::Default)
-            .paint(format!("{spacing}")),
+            .paint(spacing.to_string()),
         errors
             .styles
             .style(&Styled::Tag(severity, true))
@@ -198,11 +198,11 @@ fn log_line_carets(
         errors
             .styles
             .style(&Styled::Tag(severity, true))
-            .paint(format!("{}", pointer.msg.as_ref().map_or("", |_| "<-- "))),
+            .paint(pointer.msg.as_ref().map_or("", |_| "<-- ").to_string()),
         errors
             .styles
             .style(&Styled::Tag(severity, true))
-            .paint(format!("{}", pointer.msg.as_ref().unwrap_or(&""))),
+            .paint(pointer.msg.unwrap_or("").to_string()),
     ];
     println!("{}", ANSIStrings(line_carets));
 }

--- a/src/rivers.rs
+++ b/src/rivers.rs
@@ -7,7 +7,7 @@ use png::{ColorType, Decoder};
 
 use crate::everything::Everything;
 use crate::fileset::{FileEntry, FileHandler};
-use crate::report::{error, error_info, will_log, ErrorKey};
+use crate::report::{error, error_info, will_maybe_log, ErrorKey};
 
 #[derive(Clone, Debug, Default)]
 pub struct Rivers {
@@ -169,7 +169,7 @@ impl Rivers {
         }
 
         // Early exit before expensive loop, if errors won't be logged anyway
-        if !will_log(self.entry.as_ref().unwrap(), ErrorKey::Rivers) {
+        if !will_maybe_log(self.entry.as_ref().unwrap(), ErrorKey::Rivers) {
             return;
         }
 

--- a/src/scriptvalue.rs
+++ b/src/scriptvalue.rs
@@ -117,7 +117,7 @@ fn validate_inner(
 
             // Check for target = { script_value }
             sc.open_builder();
-            if validate_scope_chain(token, data, sc, matches!(cmp, Comparator::QEq)) {
+            if validate_scope_chain(token, data, sc, matches!(cmp, Comparator::ConditionalEquals)) {
                 if let Some(block) = bv.expect_block() {
                     sc.finalize_builder();
                     let vd = Validator::new(block, data);

--- a/src/scriptvalue.rs
+++ b/src/scriptvalue.rs
@@ -1,5 +1,5 @@
 use crate::block::validator::Validator;
-use crate::block::{Block, Comparator, BV};
+use crate::block::{Block, Comparator, Eq::*, BV};
 use crate::context::ScopeContext;
 use crate::everything::Everything;
 use crate::helpers::TriBool;
@@ -117,7 +117,7 @@ fn validate_inner(
 
             // Check for target = { script_value }
             sc.open_builder();
-            if validate_scope_chain(token, data, sc, matches!(cmp, Comparator::ConditionalEquals)) {
+            if validate_scope_chain(token, data, sc, matches!(cmp, Comparator::Equals(Question))) {
                 if let Some(block) = bv.expect_block() {
                     sc.finalize_builder();
                     let vd = Validator::new(block, data);

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use crate::block::validator::Validator;
-use crate::block::{Block, Comparator, Date, BV};
+use crate::block::{Block, Date, Comparator, BV};
 use crate::context::ScopeContext;
 use crate::data::genes::Gene;
 use crate::data::trigger_localization::TriggerLocalization;
@@ -288,7 +288,7 @@ pub fn validate_trigger_key_bv(
                 sc.expect(inscopes, &prefix);
                 validate_prefix_reference(&prefix, &arg, data);
                 if prefix.is("scope") {
-                    if last && matches!(cmp, Comparator::QEq) {
+                    if last && matches!(cmp, Comparator::ConditionalEquals) {
                         // If the comparator is ?=, it's an implicit existence check
                         sc.exists_scope(arg.as_str(), part);
                     }
@@ -367,11 +367,11 @@ pub fn validate_trigger_key_bv(
         return;
     }
 
-    if !matches!(cmp, Comparator::Eq | Comparator::QEq) {
+    if !matches!(cmp, Comparator::Eq | Comparator::ConditionalEquals) {
         if sc.can_be(Scopes::Value) {
             sc.close();
             validate_scriptvalue(bv, data, sc);
-        } else if matches!(cmp, Comparator::Ne | Comparator::EEq) {
+        } else if matches!(cmp, Comparator::NotEquals | Comparator::Equals) {
             let scopes = sc.scopes();
             sc.close();
             if let Some(token) = bv.expect_value() {
@@ -724,7 +724,7 @@ fn match_trigger_bv(
         }
     }
 
-    if matches!(cmp, Comparator::Eq | Comparator::QEq | Comparator::EEq) {
+    if matches!(cmp, Comparator::Eq | Comparator::ConditionalEquals | Comparator::Equals) {
         if warn_if_eq {
             let msg = format!("`{name} {cmp}` means exactly equal to that amount, which is usually not what you want");
             warn(name, ErrorKey::Logic, &msg);

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use crate::block::validator::Validator;
-use crate::block::{Block, Date, Comparator, BV};
+use crate::block::{Block, Comparator, Date, Eq::*, BV};
 use crate::context::ScopeContext;
 use crate::data::genes::Gene;
 use crate::data::trigger_localization::TriggerLocalization;
@@ -288,7 +288,7 @@ pub fn validate_trigger_key_bv(
                 sc.expect(inscopes, &prefix);
                 validate_prefix_reference(&prefix, &arg, data);
                 if prefix.is("scope") {
-                    if last && matches!(cmp, Comparator::ConditionalEquals) {
+                    if last && matches!(cmp, Comparator::Equals(Question)) {
                         // If the comparator is ?=, it's an implicit existence check
                         sc.exists_scope(arg.as_str(), part);
                     }
@@ -367,11 +367,11 @@ pub fn validate_trigger_key_bv(
         return;
     }
 
-    if !matches!(cmp, Comparator::Eq | Comparator::ConditionalEquals) {
+    if !matches!(cmp, Comparator::Equals(Single | Question)) {
         if sc.can_be(Scopes::Value) {
             sc.close();
             validate_scriptvalue(bv, data, sc);
-        } else if matches!(cmp, Comparator::NotEquals | Comparator::Equals) {
+        } else if matches!(cmp, Comparator::NotEquals | Comparator::Equals(Double)) {
             let scopes = sc.scopes();
             sc.close();
             if let Some(token) = bv.expect_value() {
@@ -696,7 +696,7 @@ fn match_trigger_bv(
                                 let synthetic_bv = BV::Value(key.clone());
                                 validate_trigger_key_bv(
                                     &target,
-                                    Comparator::Eq,
+                                    Comparator::Equals(Single),
                                     &synthetic_bv,
                                     data,
                                     sc,
@@ -724,7 +724,7 @@ fn match_trigger_bv(
         }
     }
 
-    if matches!(cmp, Comparator::Eq | Comparator::ConditionalEquals | Comparator::Equals) {
+    if matches!(cmp, Comparator::Equals(_)) {
         if warn_if_eq {
             let msg = format!("`{name} {cmp}` means exactly equal to that amount, which is usually not what you want");
             warn(name, ErrorKey::Logic, &msg);


### PR DESCRIPTION
- Extracts all filter-related code into its own file.
- Completely revamped filter syntax and logic. Filters are now built like triggers, using NOT, OR, etc. This makes it easier to apply more complex filters. Whitelisting keys and files also becomes much easier.
- Added a guide in `filter.md`