### PR TITLE
Add argument for custom config file

### DIFF
--- a/ck3-tiger/src/bin/ck3-tiger-auto.rs
+++ b/ck3-tiger/src/bin/ck3-tiger-auto.rs
@@ -134,7 +134,7 @@ fn validate_mod(ck3: &Path, modpath: &Path, logdir: &Path) -> Result<()> {
     eprintln!("Writing error reports to {} ...", output_file.display());
     eprintln!("This will take a few seconds.");
 
-    let mut everything = Everything::new(Some(ck3), &modpath, modfile.replace_paths())?;
+    let mut everything = Everything::new(None, Some(ck3), &modpath, modfile.replace_paths())?;
 
     // Unfortunately have to disable the colors by default because
     // on Windows there's no easy way to view a file that contains those escape sequences.

--- a/ck3-tiger/src/bin/ck3-tiger.rs
+++ b/ck3-tiger/src/bin/ck3-tiger.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 
 use tiger_lib::{
     disable_ansi_colors, emit_reports, find_game_directory_steam, set_show_loaded_mods,
-    set_show_vanilla, Everything, Game, ModFile,
+    set_show_vanilla, validate_config_file, Everything, Game, ModFile,
 };
 
 /// Steam's code for Crusader Kings 3
@@ -25,6 +25,9 @@ struct Cli {
     /// Path to CK3 main directory.
     #[clap(long)]
     ck3: Option<PathBuf>,
+    /// Path to custom .conf file.
+    #[clap(long)]
+    config: Option<PathBuf>,
     /// Show errors in the base CK3 script code as well
     #[clap(long)]
     show_vanilla: bool,
@@ -85,6 +88,8 @@ fn main() -> Result<()> {
         bail!("Cannot find CK3 directory. Please supply it as the --ck3 option.");
     }
 
+    args.config = validate_config_file(args.config);
+
     if args.show_vanilla {
         eprintln!("Showing warnings for base game files too. There will be many false positives in those.");
     }
@@ -116,7 +121,12 @@ fn main() -> Result<()> {
     }
     eprintln!("Using mod directory: {}", modpath.display());
 
-    let mut everything = Everything::new(args.ck3.as_deref(), &modpath, modfile.replace_paths())?;
+    let mut everything = Everything::new(
+        args.config.as_deref(),
+        args.ck3.as_deref(),
+        &modpath,
+        modfile.replace_paths(),
+    )?;
 
     // Print a blank line between the preamble and the first report:
     eprintln!();

--- a/ck3-tiger/src/bin/scan-mod-ck3-tiger.rs
+++ b/ck3-tiger/src/bin/scan-mod-ck3-tiger.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
     }
     eprintln!("Using mod directory: {}", modpath.display());
 
-    let mut everything = Everything::new(None, &modpath, modfile.replace_paths())?;
+    let mut everything = Everything::new(None, None, &modpath, modfile.replace_paths())?;
 
     everything.load_all();
 

--- a/imperator-tiger/src/main.rs
+++ b/imperator-tiger/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 
 use tiger_lib::{
     disable_ansi_colors, emit_reports, find_game_directory_steam, set_show_loaded_mods,
-    set_show_vanilla, Everything, Game, ModFile,
+    set_show_vanilla, validate_config_file, Everything, Game, ModFile,
 };
 
 /// Steam's code for Imperator
@@ -25,6 +25,9 @@ struct Cli {
     /// Path to Imperator directory.
     #[clap(long)]
     imperator: Option<PathBuf>,
+    /// Path to custom .conf file.
+    #[clap(long)]
+    config: Option<PathBuf>,
     /// Show errors in the base Imperator script code as well.
     #[clap(long)]
     show_vanilla: bool,
@@ -83,6 +86,8 @@ fn main() -> Result<()> {
         bail!("Cannot find Imperator directory. Please supply it as the --imperator option.");
     }
 
+    args.config = validate_config_file(args.config);
+
     if args.show_vanilla {
         eprintln!("Showing warnings for base game files too. There will be many false positives in those.");
     }
@@ -111,7 +116,8 @@ fn main() -> Result<()> {
     }
     eprintln!("Using mod directory: {}", modpath.display());
 
-    let mut everything = Everything::new(args.imperator.as_deref(), &modpath, Vec::new())?;
+    let mut everything =
+        Everything::new(args.config.as_deref(), args.imperator.as_deref(), &modpath, Vec::new())?;
 
     // Print a blank line between the preamble and the first report:
     eprintln!();

--- a/src/config_load.rs
+++ b/src/config_load.rs
@@ -38,7 +38,7 @@ pub fn validate_config_file(config: Option<PathBuf>) -> Option<PathBuf> {
     match config {
         Some(config) => {
             if config.is_file() {
-                if config.extension().map(|s| s != "conf").unwrap_or(false) {
+                if config.extension().is_some_and(|s| s != "conf") {
                     eprintln!(
                         "{} is not a valid .conf file. Using the default conf file instead.",
                         config.display()

--- a/src/config_load.rs
+++ b/src/config_load.rs
@@ -32,6 +32,34 @@ pub fn check_for_legacy_ignore(config: &Block) {
     }
 }
 
+/// Check if config file that was passed in with --conf argument is valid.
+/// If it is not valid let the user know, set it to None, and use the default one instead.
+pub fn validate_config_file(config: Option<PathBuf>) -> Option<PathBuf> {
+    match config {
+        Some(config) => {
+            if config.is_file() {
+                if config.extension().map(|s| s != "conf").unwrap_or(false) {
+                    eprintln!(
+                        "{} is not a valid .conf file. Using the default conf file instead.",
+                        config.display()
+                    );
+                    None
+                } else {
+                    eprintln!("Using conf file: {}", config.display());
+                    Some(config)
+                }
+            } else {
+                eprintln!(
+                    "{} is not a valid file. Using the default conf file instead.",
+                    config.display()
+                );
+                None
+            }
+        }
+        None => None,
+    }
+}
+
 pub fn load_filter(config: &Block) {
     assert_one_key("filter", config);
     if let Some(filter) = config.get_field_block("filter") {

--- a/src/everything.rs
+++ b/src/everything.rs
@@ -187,6 +187,7 @@ impl Everything {
     ///
     /// `replace_paths` is from the similarly named field in the `.mod` file.
     pub fn new(
+        config_filepath: Option<&Path>,
         vanilla_dir: Option<&Path>,
         mod_root: &Path,
         replace_paths: Vec<PathBuf>,
@@ -202,7 +203,11 @@ impl Everything {
             Game::Imperator => "imperator-tiger.conf",
         };
 
-        let config_file = mod_root.join(config_file_name);
+        let config_file = match config_filepath {
+            Some(path) => path.to_path_buf(),
+            None => mod_root.join(config_file_name),
+        };
+
         let config = if config_file.is_file() {
             Self::_read_config(config_file_name, &config_file)
                 .ok_or(FilesError::ConfigUnreadable { path: config_file })?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ compile_error!("features \"ck3\", \"vic3\", and \"imperator\" cannot be enabled 
 #[cfg(all(not(feature = "ck3"), not(feature = "vic3"), not(feature = "imperator")))]
 compile_error!("exactly one of the features \"ck3\", \"vic3\", \"imperator\" must be enabled");
 
+pub use crate::config_load::validate_config_file;
 pub use crate::everything::Everything;
 pub use crate::fileset::FileKind;
 pub use crate::game::Game;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -14,7 +14,7 @@ fn check_mod_helper(modname: &str) -> Vec<LogReport> {
     let vanilla_dir = PathBuf::from("tests/files/ck3");
     let mod_root = PathBuf::from(format!("tests/files/{}", modname));
 
-    let mut everything = Everything::new(Some(&vanilla_dir), &mod_root, Vec::new()).unwrap();
+    let mut everything = Everything::new(None, Some(&vanilla_dir), &mod_root, Vec::new()).unwrap();
     everything.load_all();
     everything.validate_all();
 

--- a/vic3-tiger/src/bin/vic3-tiger-auto.rs
+++ b/vic3-tiger/src/bin/vic3-tiger-auto.rs
@@ -134,7 +134,7 @@ fn validate_mod(vic3: &Path, modpath: &Path, logdir: &Path) -> Result<()> {
     eprintln!("Writing error reports to {} ...", output_file.display());
     eprintln!("This will take a few seconds.");
 
-    let mut everything = Everything::new(Some(vic3), &modpath, modfile.replace_paths())?;
+    let mut everything = Everything::new(None, Some(vic3), &modpath, modfile.replace_paths())?;
 
     // Unfortunately have to disable the colors by default because
     // on Windows there's no easy way to view a file that contains those escape sequences.

--- a/vic3-tiger/src/bin/vic3-tiger.rs
+++ b/vic3-tiger/src/bin/vic3-tiger.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 
 use tiger_lib::{
     disable_ansi_colors, emit_reports, find_game_directory_steam, set_show_loaded_mods,
-    set_show_vanilla, Everything, Game,
+    set_show_vanilla, validate_config_file, Everything, Game,
 };
 
 /// Steam's code for Victoria 3
@@ -25,6 +25,9 @@ struct Cli {
     /// Path to Vic3 directory.
     #[clap(long)]
     vic3: Option<PathBuf>,
+    /// Path to custom .conf file.
+    #[clap(long)]
+    config: Option<PathBuf>,
     /// Show errors in the base Vic3 script code as well.
     #[clap(long)]
     show_vanilla: bool,
@@ -81,6 +84,8 @@ fn main() -> Result<()> {
         bail!("Cannot find Vic3 directory. Please supply it as the --vic3 option.");
     }
 
+    args.config = validate_config_file(args.config);
+
     if args.show_vanilla {
         eprintln!("Showing warnings for base game files too. There will be many false positives in those.");
     }
@@ -107,7 +112,8 @@ fn main() -> Result<()> {
     }
     eprintln!("Using mod directory: {}", args.modpath.display());
 
-    let mut everything = Everything::new(args.vic3.as_deref(), &args.modpath, Vec::new())?;
+    let mut everything =
+        Everything::new(args.config.as_deref(), args.vic3.as_deref(), &args.modpath, Vec::new())?;
 
     // Print a blank line between the preamble and the first report:
     eprintln!();


### PR DESCRIPTION
Adds a new --config argument to each program to allow the user to load a custom configuration file. I tested with all 3 versions and it seems to be working for all of them. You may want to implement validate_config_file() in a slightly different way but it looks like it works fine to me.