### PR TITLE
remove leading underscores from function names

### DIFF
--- a/src/ck3/data/provinces.rs
+++ b/src/ck3/data/provinces.rs
@@ -333,7 +333,7 @@ pub struct Adjacency {
     comment: Token,
 }
 
-fn _verify<T: FromStr>(v: &Token, msg: &str) -> Option<T> {
+fn verify_field<T: FromStr>(v: &Token, msg: &str) -> Option<T> {
     let r = v.as_str().parse().ok();
     if r.is_none() {
         err(ErrorKey::ParseError).msg(msg).loc(v).push();
@@ -355,13 +355,13 @@ impl Adjacency {
             return None;
         }
 
-        let from = _verify(&csv[0], "expected province id");
-        let to = _verify(&csv[1], "expected province id");
-        let through = _verify(&csv[3], "expected province id");
-        let start_x = _verify(&csv[4], "expected x coordinate");
-        let start_y = _verify(&csv[5], "expected y coordinate");
-        let stop_x = _verify(&csv[6], "expected x coordinate");
-        let stop_y = _verify(&csv[7], "expected y coordinate");
+        let from = verify_field(&csv[0], "expected province id");
+        let to = verify_field(&csv[1], "expected province id");
+        let through = verify_field(&csv[3], "expected province id");
+        let start_x = verify_field(&csv[4], "expected x coordinate");
+        let start_y = verify_field(&csv[5], "expected y coordinate");
+        let stop_x = verify_field(&csv[6], "expected x coordinate");
+        let stop_y = verify_field(&csv[7], "expected y coordinate");
 
         Some(Adjacency {
             line,
@@ -405,10 +405,10 @@ impl Province {
             return None;
         }
 
-        let id = _verify(&csv[0], "expected province id")?;
-        let r = _verify(&csv[1], "expected red value")?;
-        let g = _verify(&csv[2], "expected green value")?;
-        let b = _verify(&csv[3], "expected blue value")?;
+        let id = verify_field(&csv[0], "expected province id")?;
+        let r = verify_field(&csv[1], "expected red value")?;
+        let g = verify_field(&csv[2], "expected green value")?;
+        let b = verify_field(&csv[3], "expected blue value")?;
         let color = Rgb::from([r, g, b]);
         Some(Province { key: csv[0].clone(), id, color, comment: csv[4].clone() })
     }

--- a/src/everything.rs
+++ b/src/everything.rs
@@ -210,7 +210,7 @@ impl Everything {
         };
 
         let config = if config_file.is_file() {
-            Self::_read_config(config_file_name, &config_file)
+            Self::read_config(config_file_name, &config_file)
                 .ok_or(FilesError::ConfigUnreadable { path: config_file })?
         } else {
             Block::new(Loc::for_file(config_file.clone(), FileKind::Mod, config_file.clone()))
@@ -276,7 +276,7 @@ impl Everything {
         })
     }
 
-    fn _read_config(name: &str, path: &Path) -> Option<Block> {
+    fn read_config(name: &str, path: &Path) -> Option<Block> {
         let entry = FileEntry::new(PathBuf::from(name), FileKind::Mod, path.to_path_buf());
         PdxFile::read_optional_bom(&entry)
     }


### PR DESCRIPTION
The leading underscore was used for some private functions and methods, but it's not the Rust convention.