### PR TITLE
loca: verified that [ ] inside argument strings does not work

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -203,10 +203,6 @@ pub struct Code {
 }
 
 /// `CodeArg` represents a single argument of a [`Code`].
-// Possibly the literal arguments can themselves contain [ ] code blocks.
-// I'll have to test that.
-// A literal argument can be a string that starts with a (datatype) in front
-// of it, such as '(int32)0'.
 #[derive(Clone, Debug)]
 pub enum CodeArg {
     /// An argument that is itself a [`CodeChain`], though it doesn't need the `[` `]` around it.

--- a/src/parse/localization.rs
+++ b/src/parse/localization.rs
@@ -472,8 +472,13 @@ impl<'a> ValueParser<'a> {
                 while let Some(c) = self.peek() {
                     match c {
                         '\'' => break,
-                        ']' | ')' if parens == 0 => warn(ErrorKey::Localization)
-                            .msg("Possible unterminated argument string")
+                        ']' => {
+                            let msg = "possible unterminated argument string";
+                            let info = "Using [ ] inside argument strings does not work";
+                            warn(ErrorKey::Localization).msg(msg).info(info).loc(self.loc).push();
+                        }
+                        ')' if parens == 0 => warn(ErrorKey::Localization)
+                            .msg("possible unterminated argument string")
                             .loc(self.loc)
                             .push(),
                         '(' => parens += 1,


### PR DESCRIPTION
Also fixed a minor bug in the parser's warnings: `a | b if X` applies the `if` to both a and b, but it was only intended for b here.