### PR TITLE
Use steamlocate crate to find base game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +547,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -996,6 +1032,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyvalues-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4c8354918309196302015ac9cae43362f1a13d0d5c5539a33b4c2fd2cd6d25"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "thiserror",
+]
+
+[[package]]
+name = "keyvalues-serde"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0447866c47c00f8bd1949618e8f63017cf93e985b4684dc28d784527e2882390"
+dependencies = [
+ "keyvalues-parser",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1064,16 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1157,10 +1225,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -1437,6 +1556,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1754,6 +1884,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "steamlocate"
+version = "2.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b6a4810c4e7fecb0123a9a8ba99b335c17d92e636c265ef99108ee4734c812"
+dependencies = [
+ "crc",
+ "dirs",
+ "keyvalues-parser",
+ "keyvalues-serde",
+ "serde",
+ "winreg 0.51.0",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,9 +2041,9 @@ dependencies = [
  "home",
  "regex",
  "self_update",
+ "steamlocate",
  "thiserror",
  "tiger-lib",
- "winreg 0.52.0",
 ]
 
 [[package]]
@@ -2094,6 +2238,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-bidi"
@@ -2465,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.52.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+checksum = "937f3df7948156640f46aacef17a70db0de5917bda9c92b0f751f3a955b588fc"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/ck3-tiger/src/lib.rs
+++ b/ck3-tiger/src/lib.rs
@@ -4,8 +4,7 @@ pub const GAME_CONSTS: &GameConsts = &GameConsts {
     name: "Crusader Kings 3",
     name_short: "CK3",
     version: "1.12.3 (SCYTHE)",
-    dir: "steamapps/common/Crusader Kings III",
-    app_id: "1158310",
+    app_id: 1158310,
     signature_file: "game/events/witch_events.txt",
     paradox_dir: "Crusader Kings III",
 };

--- a/imperator-tiger/src/lib.rs
+++ b/imperator-tiger/src/lib.rs
@@ -4,8 +4,7 @@ pub const GAME_CONSTS: &GameConsts = &GameConsts {
     name: "Imperator Rome",
     name_short: "Imperator",
     version: "2.0.4",
-    dir: "steamapps/common/ImperatorRome",
-    app_id: "859580",
+    app_id: 859580,
     signature_file: "game/events/000_johan_debug.txt",
     paradox_dir: "Imperator",
 };

--- a/tiger-bin-shared/Cargo.toml
+++ b/tiger-bin-shared/Cargo.toml
@@ -18,11 +18,11 @@ clap = { version = "~4.4", features = ["derive"] }
 console = "0.15"
 home = "0.5"
 regex = "1.10"
+steamlocate = "2.0.0-beta.2"
 thiserror = "1"
 
 [target.'cfg(windows)'.dependencies]
 ansiterm = "0.12.2"
-winreg = "0.52"
 
 [features]
 default = ["ck3"]

--- a/tiger-bin-shared/src/auto.rs
+++ b/tiger-bin-shared/src/auto.rs
@@ -49,7 +49,6 @@ pub fn run(game_consts: &GameConsts) -> Result<()> {
 
     let mut entries: Vec<_> =
         read_dir(pdxmod)?.filter_map(|entry| entry.ok()).filter(is_local_mod_entry).collect();
-    dbg!(&entries);
     entries.sort_by_key(|entry| entry.file_name());
 
     if entries.len() == 1 {

--- a/tiger-bin-shared/src/gamedir.rs
+++ b/tiger-bin-shared/src/gamedir.rs
@@ -1,22 +1,10 @@
 //! Helper functions for finding the base and mod directories of the game being validated.
 
-use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
+use anyhow::{bail, Result};
 use home::home_dir;
-
-#[cfg(windows)]
-use winreg::enums::HKEY_LOCAL_MACHINE;
-#[cfg(windows)]
-use winreg::RegKey;
-
-// How to find steamapps dir on different systems
-const STEAM_LINUX: &str = ".local/share/Steam";
-const STEAM_LINUX_PROTON: &str = ".steam/steam";
-const STEAM_MAC: &str = "Library/Application Support/Steam";
-const STEAM_WINDOWS: &str = "C:/Program Files (x86)/Steam";
-#[cfg(windows)]
-const STEAM_WINDOWS_KEY: &str = r"SOFTWARE\Wow6432Node\Valve\Steam";
+use steamlocate::SteamDir;
 
 // How to find the paradox local files dir on different systems
 const PDX_LINUX: &str = ".local/share/Paradox Interactive";
@@ -24,84 +12,15 @@ const PDX_MAC: &str = "Library/Application Support/Paradox Interactive"; // TODO
 const PDX_WINDOWS: &str = "Documents/Paradox Interactive";
 
 /// Tries to locate the game files.
-/// If there are several locations where the files may reside, it will try them one by one.
-/// `steam_app_id` is the (normally numeric) id of the game on Steam.
+/// `steam_app_id` is the numeric id of the game on Steam.
 /// You can find it by going to the game's store page in your web browser. The id will be after `/app/` in the url.
-/// `game_dir` is the path to the game's files under the steam path for the app. Usually `steamapps/common/...`.
-pub fn find_game_directory_steam(steam_app_id: &str, game_dir: &Path) -> Option<PathBuf> {
-    if let Some(home) = home_dir() {
-        for try_dir in &[STEAM_LINUX, STEAM_LINUX_PROTON, STEAM_MAC] {
-            let steam_dir = find_game_dir_in_steam_dir(
-                &home.join(try_dir).join("steamapps"),
-                steam_app_id,
-                game_dir,
-            );
-            if steam_dir.is_some() {
-                return steam_dir;
-            }
-            // Try the default directory too
-            let steam_dir = home.join(try_dir).join(game_dir);
-            if steam_dir.is_dir() {
-                return Some(fix_slashes_for_target_platform(steam_dir));
-            }
-        }
+pub fn find_game_directory_steam(steam_app_id: u32) -> Result<PathBuf> {
+    let steamdir = SteamDir::locate()?;
+    if let Some((app, library)) = steamdir.find_app(steam_app_id)? {
+        Ok(library.resolve_app_dir(&app))
+    } else {
+        bail!("Game not found in Steam library")
     }
-
-    let on_windows = find_game_dir_in_steam_dir(
-        &PathBuf::from(STEAM_WINDOWS).join("steamapps"),
-        steam_app_id,
-        game_dir,
-    );
-    if on_windows.is_some() {
-        return on_windows;
-    }
-
-    let on_windows = PathBuf::from(STEAM_WINDOWS).join(game_dir);
-    if on_windows.is_dir() {
-        return Some(fix_slashes_for_target_platform(on_windows));
-    }
-
-    // If the game is not in the default dirs, go via the registry to find Steam and then find the game
-    #[cfg(windows)]
-    {
-        let key = RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey(STEAM_WINDOWS_KEY).ok()?;
-        let on_windows: String = key.get_value("InstallPath").ok()?;
-        let on_windows = PathBuf::from(on_windows).join("steamapps");
-        find_game_dir_in_steam_dir(&on_windows, steam_app_id, game_dir)
-    }
-    #[cfg(not(windows))]
-    None
-}
-
-/// Tries to find the game's directory inside a steamapps/ directory.
-/// Returns None if the steamapps/ directory doesn't exist, or isn't really a steamapps directory,
-/// or doesn't contain the game.
-fn find_game_dir_in_steam_dir(steam_dir: &Path, app_id: &str, game_dir: &Path) -> Option<PathBuf> {
-    if !steam_dir.is_dir() {
-        return None;
-    }
-    let vdf = steam_dir.join("libraryfolders.vdf");
-    // Rudimentary libraryfolders.vdf parsing.
-    // We're looking for a subsection with a "path" setting that has
-    // our app listed in its "apps" list.
-    let mut found_path = None;
-    for line in read_to_string(vdf).ok()?.lines() {
-        let fields = line.split_ascii_whitespace().collect::<Vec<&str>>();
-        if fields.len() == 2 {
-            let key = fields[0].trim_matches('"');
-            let value = fields[1].trim_matches('"');
-            if key == "path" {
-                found_path = Some(PathBuf::from(value));
-            } else if key == app_id && found_path.is_some() {
-                let game_path = found_path.unwrap().join(game_dir);
-                if game_path.is_dir() {
-                    return Some(fix_slashes_for_target_platform(game_path));
-                }
-                return None;
-            }
-        }
-    }
-    None
 }
 
 pub fn find_paradox_directory(dir_under: &Path) -> Option<PathBuf> {

--- a/tiger-bin-shared/src/lib.rs
+++ b/tiger-bin-shared/src/lib.rs
@@ -12,10 +12,8 @@ pub struct GameConsts {
     pub name_short: &'static str,
     /// Latest supported version
     pub version: &'static str,
-    /// directory under steam library dir
-    pub dir: &'static str,
     /// steam ID
-    pub app_id: &'static str,
+    pub app_id: u32,
     /// A file that should be present if this is the correct game directory
     pub signature_file: &'static str,
     /// The directory under the Paradox Interactive directory for local files

--- a/tiger-bin-shared/src/tiger.rs
+++ b/tiger-bin-shared/src/tiger.rs
@@ -83,8 +83,7 @@ struct ValidateArgs {
 ///
 /// It provides a number of command line arguments, as well as self-updating capability with the `update` subcommand.
 pub fn run(game_consts: &GameConsts, current_version: &str) -> Result<()> {
-    let &GameConsts { name, name_short, version, dir, app_id, signature_file, paradox_dir: _ } =
-        game_consts;
+    let &GameConsts { name, name_short, version, app_id, signature_file, .. } = game_consts;
     let cli = Cli::parse();
 
     match cli.command {
@@ -105,7 +104,7 @@ pub fn run(game_consts: &GameConsts, current_version: &str) -> Result<()> {
             eprintln!("!! Currently it's inaccurate anyway because it's in beta state.");
 
             if args.game.is_none() {
-                args.game = find_game_directory_steam(app_id, &PathBuf::from(dir));
+                args.game = find_game_directory_steam(app_id).ok();
             }
             if let Some(ref mut game) = args.game {
                 eprintln!("Using {name_short} directory: {}", game.display());

--- a/vic3-tiger/src/lib.rs
+++ b/vic3-tiger/src/lib.rs
@@ -4,8 +4,7 @@ pub const GAME_CONSTS: &GameConsts = &GameConsts {
     name: "Victoria 3",
     name_short: "Vic3",
     version: "1.6.2 (BLACKCURRANT)",
-    dir: "steamapps/common/Victoria 3",
-    app_id: "529340",
+    app_id: 529340,
     signature_file: "game/events/titanic_events.txt",
     paradox_dir: "Victoria 3",
 };


### PR DESCRIPTION
The issue I had with it not finding my "real" installation is being addressed upstream with a function to find all steam installations.