### PR TITLE
Update effect_validation.rs - Gold field is not required for create_inspiration effect.

### DIFF
--- a/src/ck3/effect_validation.rs
+++ b/src/ck3/effect_validation.rs
@@ -1530,7 +1530,6 @@ pub fn validate_create_inspiration(
             let mut vd = Validator::new(block, data);
             vd.set_case_sensitive(false);
             vd.req_field("type");
-            vd.req_field("gold");
             vd.field_item("type", Item::Inspiration);
             vd.field_script_value("gold", sc);
         }


### PR DESCRIPTION
Gold is not a required field for create_inspiration effect. It is used to override the base cost of the given inspiration type.