### PR TITLE
Column overflow fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 /target/
 */benches/config.toml
 cachegrind.out*

--- a/src/token.rs
+++ b/src/token.rs
@@ -24,7 +24,7 @@ pub struct Loc {
     pub kind: FileKind,
     /// line 0 means the loc applies to the file as a whole.
     pub line: u32,
-    pub column: u16,
+    pub column: u32,
     /// Used in macro expansions to point to the macro invocation
     /// in the macro table
     pub link_idx: Option<MacroMapIndex>,

--- a/src/token.rs
+++ b/src/token.rs
@@ -212,7 +212,7 @@ impl Token {
         let mut loc = self.loc;
         let mut lines: u32 = 0;
         for (cols, (i, c)) in self.s.char_indices().enumerate() {
-            let cols = u16::try_from(cols).expect("internal error: 2^16 columns");
+            let cols = u32::try_from(cols).expect("internal error: 2^32 columns");
             if c == ch {
                 vec.push(self.subtoken(pos..i, loc));
                 pos = i + 1;
@@ -237,7 +237,7 @@ impl Token {
         #[allow(clippy::cast_possible_truncation)]
         self.s.strip_prefix(pfx).map(|sfx| {
             let mut loc = self.loc;
-            loc.column += pfx.chars().count() as u16;
+            loc.column += pfx.chars().count() as u32;
             Token::from_static_str(sfx, loc)
         })
     }
@@ -251,7 +251,7 @@ impl Token {
     /// May panic if the token's column location exceeds 65535.
     pub fn split_once(&self, ch: char) -> Option<(Token, Token)> {
         for (cols, (i, c)) in self.s.char_indices().enumerate() {
-            let cols = u16::try_from(cols).expect("internal error: 2^16 columns");
+            let cols = u32::try_from(cols).expect("internal error: 2^32 columns");
             if c == ch {
                 let token1 = self.subtoken(..i, self.loc);
                 let mut loc = self.loc;
@@ -272,13 +272,13 @@ impl Token {
     #[must_use]
     pub fn split_after(&self, ch: char) -> Option<(Token, Token)> {
         for (cols, (i, c)) in self.s.char_indices().enumerate() {
-            let cols = u16::try_from(cols).expect("internal error: 2^16 columns");
+            let cols = u32::try_from(cols).expect("internal error: 2^32 columns");
             #[allow(clippy::cast_possible_truncation)] // chlen can't be more than 6
             if c == ch {
                 let chlen = ch.len_utf8();
                 let token1 = self.subtoken(..i + chlen, self.loc);
                 let mut loc = self.loc;
-                loc.column += cols + chlen as u16;
+                loc.column += cols + chlen as u32;
                 let token2 = self.subtoken(i + chlen.., loc);
                 return Some((token1, token2));
             }
@@ -304,7 +304,7 @@ impl Token {
         let mut real_start = None;
         let mut real_end = self.s.len();
         for (cols, (i, c)) in self.s.char_indices().enumerate() {
-            let cols = u16::try_from(cols).expect("internal error: 2^16 columns");
+            let cols = u32::try_from(cols).expect("internal error: 2^32 columns");
             if c != ' ' {
                 real_start = Some((cols, i));
                 break;

--- a/src/token.rs
+++ b/src/token.rs
@@ -205,7 +205,7 @@ impl Token {
     /// Updates the locs for the created subtokens.
     /// This is not meant for multiline tokens.
     /// # Panics
-    /// May panic if the token's column location exceeds 65535.
+    /// May panic if the token's column location exceeds 4,294,967,296.
     pub fn split(&self, ch: char) -> Vec<Token> {
         let mut pos = 0;
         let mut vec = Vec::new();
@@ -248,7 +248,7 @@ impl Token {
     /// This is not meant for multiline tokens.
     /// Returns `None` if `ch` was not found in the token.
     /// # Panics
-    /// May panic if the token's column location exceeds 65535.
+    /// May panic if the token's column location exceeds 4,294,967,296.
     pub fn split_once(&self, ch: char) -> Option<(Token, Token)> {
         for (cols, (i, c)) in self.s.char_indices().enumerate() {
             let cols = u32::try_from(cols).expect("internal error: 2^32 columns");
@@ -268,7 +268,7 @@ impl Token {
     /// This is not meant for multiline tokens.
     /// Returns `None` if `ch` was not found in the token.
     /// # Panics
-    /// May panic if the token's column location exceeds 65535.
+    /// May panic if the token's column location exceeds 4,294,967,296.
     #[must_use]
     pub fn split_after(&self, ch: char) -> Option<(Token, Token)> {
         for (cols, (i, c)) in self.s.char_indices().enumerate() {
@@ -299,7 +299,7 @@ impl Token {
     /// Will update the loc of the subtoken.
     /// This is not meant for multiline tokens.
     /// # Panics
-    /// May panic if the token's column location exceeds 65535.
+    /// May panic if the token's column location exceeds 4,294,967,296.
     pub fn trim(&self) -> Token {
         let mut real_start = None;
         let mut real_end = self.s.len();

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -1176,7 +1176,7 @@ pub fn partition(token: &Token) -> Vec<Part> {
     let (mut second_paren_idx, mut second_paren_col) = (0, 0);
 
     for (col, (idx, ch)) in token.as_str().char_indices().enumerate() {
-        let col = u16::try_from(col).expect("internal error: 2^16 columns");
+        let col = u32::try_from(col).expect("internal error: 2^32 columns");
         match ch {
             '.' => {
                 if paren_depth == 0 {


### PR DESCRIPTION
Some files Vic 3 files have big one-liners (like "common\terrain_manipulators\provinces\allowed_provinces.txt"). So you actually do need the extra bits on your column tracker.