### PR TITLE
disable automatic version generation.

### DIFF
--- a/tiger-bin-shared/src/tiger.rs
+++ b/tiger-bin-shared/src/tiger.rs
@@ -18,6 +18,7 @@ use crate::GameConsts;
 #[derive(Parser)]
 #[command(version)]
 #[command(propagate_version = true)]
+#[command(disable_version_flag = true)] 
 #[clap(args_conflicts_with_subcommands = true)]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
I tried changing the --game arg, but then rust panics in debug mode. Apparently an automatic version arg was generated. That is not allowed since there already is a version manually generated.

Maybe the commands above just need to be removed but I wouldn't dare touch those.