### PR TITLE
Fix valid_to_continue being a Character instead of a TaskContract

### DIFF
--- a/src/ck3/data/task_contracts.rs
+++ b/src/ck3/data/task_contracts.rs
@@ -78,7 +78,7 @@ impl DbKind for TaskContractType {
             validate_trigger(block, data, &mut sc, Tooltipped::Yes);
         });
         vd.field_validated_key_block("valid_to_continue", |key, block, data| {
-            let mut sc = ScopeContext::new(Scopes::Character, key);
+            let mut sc = ScopeContext::new(Scopes::TaskContract, key);
             validate_trigger(block, data, &mut sc, Tooltipped::No);
         });
         vd.field_validated_key_block("valid_to_keep", |key, block, data| {


### PR DESCRIPTION
For now:
![image](https://github.com/user-attachments/assets/d6966abf-f3a9-43fa-8a5e-06b39f1d055d)
But docs says:
![image](https://github.com/user-attachments/assets/c55f5015-ddfa-4c15-be72-a34ff6beaf92)
