### PR TITLE
Implement checks for cultures and split_religion entries in create_pop

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -336,6 +336,22 @@ impl Token {
         }
     }
 
+    /// Gets the field as a fixed-width decimal, specifically the value multiplied by 100,000
+    pub fn get_fixed_number(&self) -> Option<i64> {
+        if !self.s.contains('.') {
+            return Some(self.s.parse::<i64>().ok()? * 100_000);
+        }
+
+        let r = self.s.find('.')?;
+        let whole = &self.s[..r];
+        let fraction = &self.s[r + 1..];
+
+        if fraction.len() > 5 {
+            return None;
+        }
+        format!("{}{:0<5}", whole, fraction).parse::<i64>().ok()
+    }
+
     pub fn get_number(&self) -> Option<f64> {
         self.s.parse::<f64>().ok()
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -349,7 +349,7 @@ impl Token {
         if fraction.len() > 5 {
             return None;
         }
-        format!("{}{:0<5}", whole, fraction).parse::<i64>().ok()
+        format!("{whole}{fraction:0<5}").parse::<i64>().ok()
     }
 
     pub fn get_number(&self) -> Option<f64> {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1588,7 +1588,7 @@ impl<'a> Validator<'a> {
                 vd.set_max_severity(sev);
                 f(key, vd);
             }
-        })
+        });
     }
 
     /// Expect the block to contain any number of `key = { block }` fields
@@ -1603,7 +1603,7 @@ impl<'a> Validator<'a> {
             if let Some(block) = bv.expect_block() {
                 f(key, block, data);
             }
-        })
+        });
     }
 
     /// Expect the block to contain any number of unknown fields (so don't warn about unknown fields anymore).

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1551,7 +1551,7 @@ impl<'a> Validator<'a> {
     /// Expect the block to contain any number of `key = value` fields
     /// where each key is a unique Item of type itype.
     /// Run the closure `f(key, vd)` for every matching block.
-    #[cfg(feature = "vic3")]
+    #[allow(dead_code)]
     pub fn validate_item_key_values<F>(&mut self, itype: Item, mut f: F)
     where
         F: FnMut(&Token, ValueValidator),
@@ -1562,7 +1562,9 @@ impl<'a> Validator<'a> {
 
             match visited_fields.get(key.as_str()) {
                 Some(&duplicate) => dup_assign_error(key, duplicate),
-                None => { visited_fields.insert(key); },
+                None => {
+                    visited_fields.insert(key);
+                }
             }
 
             self.known_fields.push(key.as_str());
@@ -1588,7 +1590,9 @@ impl<'a> Validator<'a> {
 
             match visited_fields.get(key.as_str()) {
                 Some(&duplicate) => dup_assign_error(key, duplicate),
-                None => { visited_fields.insert(key); },
+                None => {
+                    visited_fields.insert(key);
+                }
             }
 
             self.known_fields.push(key.as_str());

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,5 +1,4 @@
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::{Bound, RangeBounds};
 use std::str::FromStr;
@@ -9,7 +8,7 @@ use crate::context::ScopeContext;
 use crate::date::Date;
 use crate::effect::validate_effect_internal;
 use crate::everything::Everything;
-use crate::helpers::dup_assign_error;
+use crate::helpers::{dup_assign_error, TigerHashSet};
 use crate::item::Item;
 use crate::lowercase::Lowercase;
 #[cfg(feature = "ck3")]
@@ -1557,13 +1556,13 @@ impl<'a> Validator<'a> {
     where
         F: FnMut(&Token, ValueValidator),
     {
-        let mut visited_fields = HashMap::new();
+        let mut visited_fields = TigerHashSet::default();
         for Field(key, _, bv) in self.block.iter_fields() {
             self.data.verify_exists(itype, key);
 
             match visited_fields.get(key.as_str()) {
                 Some(&duplicate) => dup_assign_error(key, duplicate),
-                None => { visited_fields.insert(key.as_str(), key); },
+                None => { visited_fields.insert(key); },
             }
 
             self.known_fields.push(key.as_str());
@@ -1583,13 +1582,13 @@ impl<'a> Validator<'a> {
     where
         F: FnMut(&Token, &Block, &Everything),
     {
-        let mut visited_fields = HashMap::new();
+        let mut visited_fields = TigerHashSet::default();
         for Field(key, _, bv) in self.block.iter_fields() {
             self.data.verify_exists(itype, key);
 
             match visited_fields.get(key.as_str()) {
                 Some(&duplicate) => dup_assign_error(key, duplicate),
-                None => { visited_fields.insert(key.as_str(), key); },
+                None => { visited_fields.insert(key); },
             }
 
             self.known_fields.push(key.as_str());

--- a/src/validator/value_validator.rs
+++ b/src/validator/value_validator.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Error, Formatter};
-#[cfg(feature = "ck3")]
+#[cfg(any(feature = "ck3", feature = "vic3"))]
 use std::ops::{Bound, RangeBounds};
 use std::str::FromStr;
 
@@ -301,6 +301,44 @@ impl<'a> ValueValidator<'a> {
         self.validated = true;
         // TODO: pass max_severity here
         self.value.expect_number();
+    }
+
+    /// Expect the value to be a number with up to 5 decimals within the `range` provided.
+    /// (5 decimals is the limit accepted by the game engine in most contexts).
+    #[cfg(feature = "vic3")]
+    pub fn numeric_range<R: RangeBounds<f64>>(&mut self, range: R) {
+        if self.validated {
+            return;
+        }
+        let sev = Severity::Error.at_most(self.max_severity);
+        self.validated = true;
+        // TODO: pass max_severity here
+        if let Some(f) = self.value.expect_number() {
+            if !range.contains(&f) {
+                let low = match range.start_bound() {
+                    Bound::Unbounded => None,
+                    Bound::Included(&f) => Some(format!("{f} (inclusive)")),
+                    Bound::Excluded(&f) => Some(format!("{f}")),
+                };
+                let high = match range.end_bound() {
+                    Bound::Unbounded => None,
+                    Bound::Included(&f) => Some(format!("{f} (inclusive)")),
+                    Bound::Excluded(&f) => Some(format!("{f}")),
+                };
+                let msg;
+                if low.is_some() && high.is_some() {
+                    msg =
+                        format!("should be between {} and {}", low.unwrap(), high.unwrap());
+                } else if low.is_some() {
+                    msg = format!("should be at least {}", low.unwrap());
+                } else if high.is_some() {
+                    msg = format!("should be at most {}", high.unwrap());
+                } else {
+                    unreachable!(); // could not have failed the contains check
+                }
+                report(ErrorKey::Range, sev).msg(msg).loc(self).push();
+            }
+        }
     }
 
     /// Expect the value to be a number with any number of decimals.

--- a/src/validator/value_validator.rs
+++ b/src/validator/value_validator.rs
@@ -327,8 +327,7 @@ impl<'a> ValueValidator<'a> {
                 };
                 let msg;
                 if low.is_some() && high.is_some() {
-                    msg =
-                        format!("should be between {} and {}", low.unwrap(), high.unwrap());
+                    msg = format!("should be between {} and {}", low.unwrap(), high.unwrap());
                 } else if low.is_some() {
                     msg = format!("should be at least {}", low.unwrap());
                 } else if high.is_some() {

--- a/src/vic3/effect_validation.rs
+++ b/src/vic3/effect_validation.rs
@@ -583,7 +583,7 @@ pub fn validate_create_pop(
             let mut vd = Validator::new(block, data);
             vd.validate_item_key_values(Item::Culture, |key, mut vd| {
                 available_cultures.insert(key.clone());
-                vd.numeric()
+                vd.numeric_range(0.0..=1.0)
             })
         });
     }
@@ -621,7 +621,7 @@ pub fn validate_create_pop(
 
                 let mut vd = Validator::new(block, data);
                 vd.validate_item_key_values(Item::Religion, |_, mut vd| {
-                    vd.numeric();
+                    vd.numeric_range(0.0..=1.0);
                 });
             });
 

--- a/src/vic3/effect_validation.rs
+++ b/src/vic3/effect_validation.rs
@@ -612,11 +612,18 @@ pub fn validate_create_pop(
 
                 match used_cultures.get(key) {
                     Some(duplicate) => {
-                        let msg = format!("trying to split religion of culture {} multiple times", key);
+                        let msg =
+                            format!("trying to split religion of culture {} multiple times", key);
                         let msg_other = "first split here";
-                        err(ErrorKey::DuplicateField).msg(msg).loc(key).loc_msg(duplicate, msg_other).push();
-                    },
-                    None => { used_cultures.insert(key.clone()); },
+                        err(ErrorKey::DuplicateField)
+                            .msg(msg)
+                            .loc(key)
+                            .loc_msg(duplicate, msg_other)
+                            .push();
+                    }
+                    None => {
+                        used_cultures.insert(key.clone());
+                    }
                 }
 
                 let mut vd = Validator::new(block, data);

--- a/src/vic3/effect_validation.rs
+++ b/src/vic3/effect_validation.rs
@@ -564,6 +564,7 @@ pub fn validate_create_pop(
 ) {
     // This effect is undocumented
 
+    #[allow(clippy::integer_division)]
     fn sum_fractions_warner<E: ErrorLoc>(sum_fractions: i64, loc: E) {
         if sum_fractions != 100_000 {
             let msg = format!(
@@ -626,7 +627,7 @@ pub fn validate_create_pop(
                 match used_cultures.get(key) {
                     Some(duplicate) => {
                         let msg =
-                            format!("trying to split religion of culture {} multiple times", key);
+                            format!("trying to split religion of culture {key} multiple times");
                         let msg_other = "first split here";
                         err(ErrorKey::DuplicateField)
                             .msg(msg)

--- a/src/vic3/effect_validation.rs
+++ b/src/vic3/effect_validation.rs
@@ -568,7 +568,7 @@ pub fn validate_create_pop(
     fn sum_fractions_warner<E: ErrorLoc>(sum_fractions: i64, loc: E) {
         if sum_fractions != 100_000 {
             let msg = format!(
-                "fractions should add to exactly 1, currently {}.{}",
+                "fractions should add to exactly 1, currently {}.{:05}",
                 sum_fractions / 100_000,
                 sum_fractions % 100_000,
             );


### PR DESCRIPTION
This should allow for and verify usage of the proportional syntax when creating pops, I've found it very useful when populating lots of states when I only care about the total population and vague demographics.

There's still the question mark about whether one should check that the numbers add up to ~1, if that's worth a warning. I'd think so, but I worry about spam.

I'm also a bit uncertain about best practices when emitting errors, so they might need correcting.