### PR TITLE
fix(ck3): :sparkles: update government/opinion_of_liege

### DIFF
--- a/src/ck3/data/government.rs
+++ b/src/ck3/data/government.rs
@@ -123,7 +123,12 @@ impl DbKind for Government {
         // undocumented
 
         vd.field_item("tax_slot_type", Item::TaxSlotType);
-        vd.field_script_value_rooted("opinion_of_liege", Scopes::Character);
+        vd.field_script_value_build_sc("opinion_of_liege", |key| {
+            let mut sc = ScopeContext::new(Scopes::Character, key);
+            sc.define_name("vassal", Scopes::Character, key);
+            sc.define_name("liege", Scopes::Character, key);
+            sc
+        });
         vd.field_validated_key("opinion_of_liege_desc", |key, bv, data| {
             let mut sc = ScopeContext::new(Scopes::None, key);
             sc.define_name("vassal", Scopes::Character, key);


### PR DESCRIPTION
I used scope context as in opinion_of_liege_desc case

Errors are gone:
![image](https://github.com/user-attachments/assets/ea50e531-39d9-4db9-a30c-de380b6f90c1)

Closes #147 