### PR TITLE
fix(ck3): reroot ai_potential

### DIFF
--- a/src/ck3/data/interactions.rs
+++ b/src/ck3/data/interactions.rs
@@ -298,9 +298,15 @@ impl DbKind for CharacterInteraction {
         vd.field_integer("ai_frequency"); // months
 
         // This is in character scope with no other named scopes builtin
-        vd.field_validated_block_rooted("ai_potential", Scopes::Character, |block, data, sc| {
-            validate_trigger(block, data, sc, Tooltipped::Yes);
-        });
+        vd.field_validated_block_rerooted(
+            "ai_potential",
+            &sc,
+            Scopes::Character,
+            |block, data, sc| {
+                validate_trigger(block, data, sc, Tooltipped::Yes);
+            },
+        );
+
         if let Some(token) = block.get_key("ai_potential") {
             if block.get_field_integer("ai_frequency").unwrap_or(0) == 0
                 && !key.is("revoke_title_interaction")


### PR DESCRIPTION
because otherwise it lacks scope context and doesn't see scopes like "target", "landed_title", as shown below:

![image](https://github.com/user-attachments/assets/29545ff7-3d89-4b56-8cca-91cc256e4a9f)

The same vanilla code after fix:
![image](https://github.com/user-attachments/assets/825d62d9-8050-4f70-94d7-d3615cac98ba)

I am not sure what you originally meant when you added a comment:
```
// This is in character scope with no other named scopes builtin
```


Closes #151