### PR TITLE
fix(imperator): fix arguments list for GetPortraitTexture datafunction

### DIFF
--- a/src/imperator/tables/include/data_functions.rs
+++ b/src/imperator/tables/include/data_functions.rs
@@ -2658,7 +2658,7 @@
 	("GetPortraitContext", Imperator(Portrait3dView), Args::Args(&[]), Unknown),
 	("GetPortraitEntity", Imperator(Portrait3dView), Args::Args(&[]), Unknown),
 	("GetPortraitFrameFrame", Imperator(Character), Args::Args(&[]), Unknown),
-	("GetPortraitTexture", Imperator(PortraitEditorWindow), Args::Args(&[]), Unknown),
+	("GetPortraitTexture", Imperator(PortraitEditorWindow), Args::Args(&[DType(Unknown)]), Unknown),
 	("GetPortraitTooltip", Imperator(Character), Args::Args(&[]), CString),
 	("GetPortraitTooltipNoClick", Imperator(Character), Args::Args(&[]), CString),
 	("GetPosition", Imperator(BonusLineItem), Args::Args(&[]), CVector2f),


### PR DESCRIPTION
All usages in Imperator have a single argument:
![obraz](https://github.com/user-attachments/assets/286c61ed-6840-43b1-954a-60e459776277)

Currently this results in false-positives like these:
```
warning(datafunctions): GetPortraitTexture takes 0 arguments but was given 1 here
   --> [MOD] gui\portrait_editor_window.gui
606 |                 portrait_texture = "[PortraitEditorWindow.GetPortraitTexture('male')]"
    |                                                           ^^^^^^^^^^^^^^^^^^ 

warning(datafunctions): GetPortraitTexture takes 0 arguments but was given 1 here
   --> [MOD] gui\portrait_editor_window.gui
628 |                 portrait_texture = "[PortraitEditorWindow.GetPortraitTexture('female')]"
    |                                                           ^^^^^^^^^^^^^^^^^^ 

```

Copied the code from the CK3 version.
