### PR TITLE
fix(imperator): fix false positive about monthly_character_experience

### DIFF
--- a/src/imperator/tables/modifs.rs
+++ b/src/imperator/tables/modifs.rs
@@ -160,7 +160,7 @@ static MODIF_MAP: Lazy<TigerHashMap<Lowercase<'static>, ModifKinds>> = Lazy::new
 /// See `modifiers.log` from the game data dumps.
 /// A `modif` is my name for the things that modifiers modify.
 const MODIF_TABLE: &[(&str, ModifKinds)] = &[
-    ("happiness_for_wrong_religion_modifier", ModifKinds::Province),
+    ("happiness_for_wrong_religion_modifier", ModifKinds::Province.union(ModifKinds::Country)),
     ("local_happiness_for_wrong_religion_modifier", ModifKinds::Province),
     ("cultural_assimilation_speed_modifier", ModifKinds::Country),
     ("build_cost", ModifKinds::Country),

--- a/src/imperator/tables/modifs.rs
+++ b/src/imperator/tables/modifs.rs
@@ -160,7 +160,7 @@ static MODIF_MAP: Lazy<TigerHashMap<Lowercase<'static>, ModifKinds>> = Lazy::new
 /// See `modifiers.log` from the game data dumps.
 /// A `modif` is my name for the things that modifiers modify.
 const MODIF_TABLE: &[(&str, ModifKinds)] = &[
-    ("happiness_for_wrong_religion_modifier", ModifKinds::Province.union(ModifKinds::Country)),
+    ("happiness_for_wrong_religion_modifier", ModifKinds::Province),
     ("local_happiness_for_wrong_religion_modifier", ModifKinds::Province),
     ("cultural_assimilation_speed_modifier", ModifKinds::Country),
     ("build_cost", ModifKinds::Country),
@@ -387,7 +387,7 @@ const MODIF_TABLE: &[(&str, ModifKinds)] = &[
     ("local_monthly_food_modifier", ModifKinds::Province.union(ModifKinds::State)),
     ("local_hostile_food_multiplier", ModifKinds::Province.union(ModifKinds::State)),
     ("pop_food_consumption", ModifKinds::Province.union(ModifKinds::State)),
-    ("monthly_character_experience", ModifKinds::Character),
+    ("monthly_character_experience", ModifKinds::Character.union(ModifKinds::Country)),
     ("monthly_character_experience_decay", ModifKinds::Character),
     ("monthly_conviction_for_head_of_family_party", ModifKinds::Character),
     ("local_base_trade_routes", ModifKinds::Province.union(ModifKinds::State)),


### PR DESCRIPTION
When used in country scope, it represents Monthly Statesmanship:
```
	country_modifier = {
		research_points_modifier = 0.05
		max_research_efficiency = 0.15
		monthly_character_experience = 0.05
	}
```
![image](https://github.com/user-attachments/assets/0b858146-3914-49e5-b04d-adb53fa9f5bb)
