### PR TITLE
[CK3] Implement MURMUR3A hash collision checking for localization keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
+
+[[package]]
 name = "native-tls"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2424,6 +2430,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
+ "murmur3",
  "once_cell",
  "phf 0.11.3",
  "png",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ ahash = { version = "0.8", features = [
     "std",
     "compile-time-rng",
 ], default-features = false }
+murmur3 = "0.5.2"
 
 [profile.bench]
 debug = true

--- a/src/report/error_key.rs
+++ b/src/report/error_key.rs
@@ -54,6 +54,7 @@ pub enum ErrorKey {
     TitleTier,
     Colors,
     UnusedLocalization,
+    LocalizationKeyCollision,
     UnusedFile,
     UnknownList,
     Choice,


### PR DESCRIPTION
Tested Crusader Kings 3 version:
1.12.4
1.14.2
If there are localization key hash collisions, log similar to below appears in error.log
```
[01:50:41][E][pdx_localize.cpp:267]: Localization key hash collision. Key 'THEY_GAIN_HOOK_EFFECT_STRONG' and '' have the same hash: 271466882.
[01:50:43][E][pdx_localize.cpp:267]: Localization key hash collision. Key 'game_concept_contest_rounds' and '' have the same hash: 289969640. 
```
CK3 can detect collisions but does not report them correctly in log with the tested version (maybe all versions?).
And seems these collisions would cause some of them fail to load.
```
[01:50:45][E][pdx_locstring.cpp:93]: Key is missing localization: game_concept_contest_rounds
```
It would be a very useful feature for mod developer to debug these issues especially for large mod with lots of localization entries.
I have made a quick and dirty implmentation. Currently it looks like
```
error(localization-key-collision): localization keys '["advcm_dread_baseline_loc4", "game_concept_contest_rounds"]' have same MURMUR3A hash '0x114895E8'
    --> [MOD] localization\english\gui\advcm_l_english.yml
 390 |  advcm_dread_baseline_loc4: "$advcm_dread_baseline_loc$[GetPlayer.MakeScope.Var('advcm_modifier4_value').GetValue|=+0]"
     |  ^^^^^^^^^^^^^^^^^^^^^^^^^
    --> [CK3] localization\english\game_concepts_l_english.yml
2054 |  game_concept_contest_rounds:0 "Contest Rounds"
     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ <-- this one
     = Info: localization keys hash collision will cause some of them fail to load
```
Suggestions are welcome.
