### PR TITLE
Fix holding_type parent scope type in targets.rs

### DIFF
--- a/src/ck3/tables/targets.rs
+++ b/src/ck3/tables/targets.rs
@@ -120,7 +120,7 @@ const SCOPE_TO_SCOPE: &[(Scopes, &str, Scopes)] = &[
     (Scopes::Character, "government_type", Scopes::GovernmentType),
     (Scopes::Faith, "great_holy_war", Scopes::GreatHolyWar),
     (Scopes::LandedTitle, "holder", Scopes::Character),
-    (Scopes::Character, "holding_type", Scopes::HoldingType),
+    (Scopes::Province, "holding_type", Scopes::HoldingType),
     (Scopes::HolyOrder, "holy_order_patron", Scopes::Character),
     (Scopes::Character, "home_court", Scopes::Character),
     (Scopes::Character, "host", Scopes::Character),


### PR DESCRIPTION
As talked on discord:

![image](https://github.com/user-attachments/assets/626230d8-3300-42f6-9c93-1216fa6e84a3)
