### PR TITLE
fix(vic3): Fix up scopes for political lobby definitions

### DIFF
--- a/src/vic3/data/lobbies.rs
+++ b/src/vic3/data/lobbies.rs
@@ -92,11 +92,7 @@ impl DbKind for PoliticalLobby {
         vd.field_validated_list("appeasement_factors_pro", appeasement_factors_validation);
         vd.field_validated_list("appeasement_factors_anti", appeasement_factors_validation);
 
-        vd.field_trigger_builder(
-            "available_for_interest_group",
-            Tooltipped::No,
-            sc_no_lobby,
-        );
+        vd.field_trigger_builder("available_for_interest_group", Tooltipped::No, sc_no_lobby);
 
         vd.field_script_value_no_breakdown_builder("join_weight", sc_jw);
     }


### PR DESCRIPTION
The docs are lying about scope:country