### PR TITLE
fix(imperator): correct target for `has_specific_construction`

### DIFF
--- a/src/imperator/tables/triggers.rs
+++ b/src/imperator/tables/triggers.rs
@@ -502,7 +502,7 @@ const TRIGGER: &[(Scopes, &str, Trigger)] = &[
     (Scopes::Province, "has_province_rank", Item(Item::ProvinceRank)),
     (Scopes::Province, "has_road_towards", ScopeOrItem(Scopes::Province, Item::Province)),
     (Scopes::Province, "has_siege", Boolean),
-    (Scopes::Province, "has_specific_construction", Boolean),
+    (Scopes::Province, "has_specific_construction", Item(Item::Building)),
     (Scopes::Province, "has_winter", Boolean),
     (Scopes::Province, "is_adjacent_to_major_river", Boolean),
     (Scopes::Province, "is_capital", Boolean),


### PR DESCRIPTION
Usage in vanilla:

```
  game\common\advice\low_food_supply.txt
	Line 170: 							NOT = { has_specific_construction = basic_settlement_infratructure_building }
  game\common\advice\starving_pops.txt
	Line 128: 						NOT = { has_specific_construction = basic_settlement_infratructure_building }
	Line 250: 						NOT = { has_specific_construction = population_building }
```

Usage in Invictus:
<img width="309" height="728" alt="obraz" src="https://github.com/user-attachments/assets/44f159fc-832f-4cab-83dd-06932cb7bc4d" />
