### PR TITLE
Mac Releases

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -19,11 +19,11 @@ jobs:
             extension: .exe
             archive: zip
           - os: macos-latest # ARM
-            name: Mac (ARM)
+            name: mac-arm
             extension:
             archive: zip
           - os: macos-15-intel # x86
-            name: Mac (x86/Intel)
+            name: mac-x86
             extension:
             archive: zip
     name: ${{ matrix.name }} build

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -19,9 +19,11 @@ jobs:
             extension: .exe
             archive: zip
           - os: macos-latest # ARM
+            name: Mac (ARM)
             extension:
             archive: zip
           - os: macos-15-intel # x86
+            name: Mac (x86/Intel)
             extension:
             archive: zip
     name: ${{ matrix.name }} build

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -51,10 +51,10 @@ jobs:
           echo "::set-output name=vic3_pkgdir::$vic3_pkgdir"
           echo "::set-output name=imperator_pkgdir::$imperator_pkgdir"
 
-      # - name: Verify version against tag
-      #   shell: bash
-      #   run: |
-      #     test "${{ github.ref_name }}" = "${{ steps.version.outputs.version }}"
+      - name: Verify version against tag
+        shell: bash
+        run: |
+          test "${{ github.ref_name }}" = "${{ steps.version.outputs.version }}"
 
       - name: Build CK3
         run: cargo build --release -p ck3-tiger

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -51,10 +51,10 @@ jobs:
           echo "::set-output name=vic3_pkgdir::$vic3_pkgdir"
           echo "::set-output name=imperator_pkgdir::$imperator_pkgdir"
 
-      - name: Verify version against tag
-        shell: bash
-        run: |
-          test "${{ github.ref_name }}" = "${{ steps.version.outputs.version }}"
+      # - name: Verify version against tag
+      #   shell: bash
+      #   run: |
+      #     test "${{ github.ref_name }}" = "${{ steps.version.outputs.version }}"
 
       - name: Build CK3
         run: cargo build --release -p ck3-tiger

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,6 +18,12 @@ jobs:
             name: windows
             extension: .exe
             archive: zip
+          - os: macos-latest # ARM
+            extension:
+            archive: zip
+          - os: macos-15-intel # x86
+            extension:
+            archive: zip
     name: ${{ matrix.name }} build
     runs-on: ${{ matrix.os }}
     steps:

--- a/tiger-bin-shared/Cargo.toml
+++ b/tiger-bin-shared/Cargo.toml
@@ -35,14 +35,20 @@ hoi4 = ["tiger-lib/hoi4"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 self_update = { version = "0.42", features = [
-    "archive-zip",
-    "compression-zip-deflate",
+  "archive-zip",
+  "compression-zip-deflate",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 self_update = { version = "0.42", features = [
-    "archive-tar",
-    "compression-flate2",
+  "archive-tar",
+  "compression-flate2",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+self_update = { version = "0.42", features = [
+  "archive-tar",
+  "compression-flate2",
 ] }
 
 [lints]

--- a/tiger-bin-shared/src/update.rs
+++ b/tiger-bin-shared/src/update.rs
@@ -61,8 +61,10 @@ pub fn update(current_version: &str, target_version: Option<&str>) -> Result<(),
 
             #[cfg(target_os = "linux")]
             let bin_path = format!("{BIN_NAME}-linux-v{{{{version}}}}/{BIN_NAME}");
-            #[cfg(target_os = "macos")]
-            let bin_path = format!("{BIN_NAME}-macos-v{{{{version}}}}/{BIN_NAME}");
+            #[cfg(target_os = "macos", target_arch = "arm")]
+            let bin_path = format!("{BIN_NAME}-macos-arm-v{{{{version}}}}/{BIN_NAME}");
+            #[cfg(target_os = "macos", target_arch = "x86_64")]
+            let bin_path = format!("{BIN_NAME}-macos-x86-v{{{{version}}}}/{BIN_NAME}");
             #[cfg(target_os = "windows")]
             let bin_path = format!("{}.exe", BIN_NAME);
 

--- a/tiger-bin-shared/src/update.rs
+++ b/tiger-bin-shared/src/update.rs
@@ -1,14 +1,14 @@
 use std::env::consts;
 
 use cfg_if::cfg_if;
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 use regex::Regex;
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 use self_update::backends::github::UpdateBuilder;
 use thiserror::Error;
 
 cfg_if! {
-    if #[cfg(any(target_os = "windows", target_os = "linux"))] {
+    if #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))] {
         #[derive(Debug, Error)]
         pub enum UpdateError {
             #[error("Version tag not in the format of '(v)X.Y.Z'")]
@@ -26,7 +26,7 @@ cfg_if! {
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 cfg_if! {
     if #[cfg(feature = "ck3")] {
         const BIN_NAME: &str = "ck3-tiger";
@@ -51,7 +51,7 @@ cfg_if! {
 #[allow(dead_code)]
 pub fn update(current_version: &str, target_version: Option<&str>) -> Result<(), UpdateError> {
     cfg_if! {
-        if #[cfg(any(target_os = "windows", target_os = "linux"))] {
+        if #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))] {
             if let Some(version) = target_version {
                 let re = Regex::new(r"^v?[0-9]+\.[0-9]+\.[0-9]+$").unwrap();
                 if !re.is_match(version) {
@@ -61,6 +61,8 @@ pub fn update(current_version: &str, target_version: Option<&str>) -> Result<(),
 
             #[cfg(target_os = "linux")]
             let bin_path = format!("{BIN_NAME}-linux-v{{{{version}}}}/{BIN_NAME}");
+            #[cfg(target_os = "macos")]
+            let bin_path = format!("{BIN_NAME}-macos-v{{{{version}}}}/{BIN_NAME}");
             #[cfg(target_os = "windows")]
             let bin_path = format!("{}.exe", BIN_NAME);
 

--- a/tiger-bin-shared/src/update.rs
+++ b/tiger-bin-shared/src/update.rs
@@ -61,9 +61,9 @@ pub fn update(current_version: &str, target_version: Option<&str>) -> Result<(),
 
             #[cfg(target_os = "linux")]
             let bin_path = format!("{BIN_NAME}-linux-v{{{{version}}}}/{BIN_NAME}");
-            #[cfg(target_os = "macos", target_arch = "arm")]
+            #[cfg(all(target_os = "macos", target_arch = "arm"))]
             let bin_path = format!("{BIN_NAME}-macos-arm-v{{{{version}}}}/{BIN_NAME}");
-            #[cfg(target_os = "macos", target_arch = "x86_64")]
+            #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
             let bin_path = format!("{BIN_NAME}-macos-x86-v{{{{version}}}}/{BIN_NAME}");
             #[cfg(target_os = "windows")]
             let bin_path = format!("{}.exe", BIN_NAME);


### PR DESCRIPTION
I updated the CI to build releases for Mac on x86 and ARM, I was able to confirm the x86 release worked for Victoria 3 in a mod I have been working on. Sorry for the commit messages, CI is frustrating.

I also updated `tiger-bin-shared` for mac targets.